### PR TITLE
[#175205379] Add new MetadataDescriptionEditor component

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,10 @@
     },
     "testMatch": [
       "**/__tests__/*.ts"
-    ]
+    ],
+    "moduleNameMapper": {
+      ".*css$": "<rootDir>/src/components/input/__tests__/mock.css"
+    }
   },
   "snyk": true
 }

--- a/src/components/input/MetadataDescriptionEditor.css
+++ b/src/components/input/MetadataDescriptionEditor.css
@@ -1,0 +1,4 @@
+.description-editor--message--preview
+{
+    overflow-y: auto;
+}

--- a/src/components/input/MetadataDescriptionEditor.tsx
+++ b/src/components/input/MetadataDescriptionEditor.tsx
@@ -3,7 +3,7 @@ import React, { ChangeEvent, Component } from "react";
 import { WithNamespaces, withNamespaces } from "react-i18next";
 
 import { Input } from "design-react-kit";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { NodeType } from "react-markdown";
 import { LIMITS } from "../../utils/constants";
 const { MARKDOWN } = LIMITS;
 
@@ -22,7 +22,34 @@ class MetadataDescriptionEditor extends Component<Props, never> {
   public render() {
     const { markdown, t } = this.props;
     const { onChangeMarkdown } = this.props;
-
+    // tslint:disable-next-line:readonly-array
+    const allowedTypes: NodeType[] = [
+      "root",
+      "break",
+      "paragraph",
+      "emphasis",
+      "strong",
+      // "thematicBreak",
+      // "blockquote",
+      "delete",
+      // "link",
+      // "image",
+      // "linkReference",
+      // "imageReference",
+      // "table",
+      // "tableHead",
+      // "tableBody",
+      // "tableRow",
+      // "tableCell",
+      "list",
+      "listItem",
+      // "definition",
+      "heading"
+      // "inlineCode",
+      // "code",
+      // "html",
+      // "virtualHtml"
+    ];
     return (
       <section className="pages--container">
         <section className="h-90 d-flex flex-column">
@@ -43,33 +70,7 @@ class MetadataDescriptionEditor extends Component<Props, never> {
               className="description-editor--message--preview form-control card shadow h-100 flex-1"
               source={markdown}
               unwrapDisallowed={true}
-              allowedTypes={[
-                "root",
-                "break",
-                "paragraph",
-                "emphasis",
-                "strong",
-                // "thematicBreak",
-                // "blockquote",
-                "delete",
-                // "link",
-                // "image",
-                // "linkReference",
-                // "imageReference",
-                // "table",
-                // "tableHead",
-                // "tableBody",
-                // "tableRow",
-                // "tableCell",
-                "list",
-                "listItem",
-                // "definition",
-                "heading"
-                // "inlineCode",
-                // "code",
-                // "html",
-                // "virtualHtml"
-              ]}
+              allowedTypes={allowedTypes}
             />
           </section>
         </section>

--- a/src/components/input/MetadataDescriptionEditor.tsx
+++ b/src/components/input/MetadataDescriptionEditor.tsx
@@ -1,0 +1,81 @@
+import React, { ChangeEvent, Component } from "react";
+
+import { WithNamespaces, withNamespaces } from "react-i18next";
+
+import { Input } from "design-react-kit";
+import ReactMarkdown from "react-markdown";
+import { LIMITS } from "../../utils/constants";
+const { MARKDOWN } = LIMITS;
+
+import "./MetadataDescriptionEditor.css";
+
+type OwnProps = {
+  markdown: string;
+  // tslint:disable-next-line:readonly-array
+  markdownLength: Readonly<[number, number]>;
+  isMarkdownValid: boolean;
+  onChangeMarkdown: (event: ChangeEvent<HTMLInputElement>) => void;
+};
+type Props = WithNamespaces & OwnProps;
+
+class MetadataDescriptionEditor extends Component<Props, never> {
+  public render() {
+    const { markdown, t } = this.props;
+    const { onChangeMarkdown } = this.props;
+
+    return (
+      <section className="pages--container">
+        <section className="h-90 d-flex flex-column">
+          <label className="m-0">{t("description")}</label>
+          <section className="h-100 flex-1 d-flex flex-row">
+            <section className="flex-1 h-100">
+              <Input
+                name="description"
+                className="h-100 font-weight-normal"
+                type="textarea"
+                value={markdown}
+                minLength={MARKDOWN.MIN}
+                maxLength={MARKDOWN.MAX}
+                onChange={onChangeMarkdown}
+              />
+            </section>
+            <ReactMarkdown
+              className="description-editor--message--preview form-control card shadow h-100 flex-1"
+              source={markdown}
+              unwrapDisallowed={true}
+              allowedTypes={[
+                "root",
+                "break",
+                "paragraph",
+                "emphasis",
+                "strong",
+                // "thematicBreak",
+                // "blockquote",
+                "delete",
+                // "link",
+                // "image",
+                // "linkReference",
+                // "imageReference",
+                // "table",
+                // "tableHead",
+                // "tableBody",
+                // "tableRow",
+                // "tableCell",
+                "list",
+                "listItem",
+                // "definition",
+                "heading"
+                // "inlineCode",
+                // "code",
+                // "html",
+                // "virtualHtml"
+              ]}
+            />
+          </section>
+        </section>
+      </section>
+    );
+  }
+}
+
+export default withNamespaces(["service"])(MetadataDescriptionEditor);

--- a/src/components/input/MetadataInput.tsx
+++ b/src/components/input/MetadataInput.tsx
@@ -27,9 +27,11 @@ export const MetadataKeys = ServiceMetadata.type.types.reduce(
   [] as readonly string[]
 );
 
-const InputTextMetadataKeys = MetadataKeys.filter(
-  k => k !== "scope" && k !== "description"
-);
+export const SortedMetadata: readonly string[] = [
+  "description",
+  ...MetadataKeys.filter(k => k !== "description" && k !== "scope"),
+  "scope"
+];
 
 const MetadataInput = ({
   service_metadata,
@@ -43,47 +45,54 @@ const MetadataInput = ({
      * - Select: 'scope' that is an enumeration
      */
     <div>
-      <MetadataDescriptionEditor
-        markdown={
-          service_metadata && service_metadata.description
-            ? service_metadata.description
-            : ""
-        }
-        markdownLength={[MARKDOWN.MIN, MARKDOWN.MAX]}
-        isMarkdownValid={true}
-        onChangeMarkdown={onChange}
-      />
-      {InputTextMetadataKeys.map((k, i) => (
-        <div key={i}>
-          <label className="m-0">{t(k)}</label>
-          <input
-            name={k}
-            type="text"
-            defaultValue={Object(service_metadata)[k]}
-            onChange={onChange}
-            className="mb-4"
+      {SortedMetadata.map((k, i) =>
+        k === "scope" ? (
+          <div>
+            <label className="m-0">{t("scope")}*</label>
+            <select
+              name="scope"
+              value={service_metadata ? service_metadata.scope : undefined}
+              className="form-control mb-4"
+              onChange={onChange}
+            >
+              <option
+                key={ServiceScopeEnum.NATIONAL}
+                value={ServiceScopeEnum.NATIONAL}
+              >
+                {ServiceScopeEnum.NATIONAL}
+              </option>
+              <option
+                key={ServiceScopeEnum.LOCAL}
+                value={ServiceScopeEnum.LOCAL}
+              >
+                {ServiceScopeEnum.LOCAL}
+              </option>
+            </select>
+          </div>
+        ) : k === "description" ? (
+          <MetadataDescriptionEditor
+            markdown={
+              service_metadata && service_metadata.description
+                ? service_metadata.description
+                : ""
+            }
+            markdownLength={[MARKDOWN.MIN, MARKDOWN.MAX]}
+            isMarkdownValid={true}
+            onChangeMarkdown={onChange}
           />
-        </div>
-      ))}
-      <div>
-        <label className="m-0">{t("scope")}*</label>
-        <select
-          name="scope"
-          value={service_metadata ? service_metadata.scope : undefined}
-          className="form-control mb-4"
-          onChange={onChange}
-        >
-          <option
-            key={ServiceScopeEnum.NATIONAL}
-            value={ServiceScopeEnum.NATIONAL}
-          >
-            {ServiceScopeEnum.NATIONAL}
-          </option>
-          <option key={ServiceScopeEnum.LOCAL} value={ServiceScopeEnum.LOCAL}>
-            {ServiceScopeEnum.LOCAL}
-          </option>
-        </select>
-      </div>
+        ) : (
+          <div key={i}>
+            <label className="m-0">{t(k)}</label>
+            <input
+              name={k}
+              type="text"
+              defaultValue={Object(service_metadata)[k]}
+              onChange={onChange}
+              className="mb-4"
+            />
+          </div>
+        )
+      )}
     </div>
   ) : null;
 };

--- a/src/components/input/MetadataInput.tsx
+++ b/src/components/input/MetadataInput.tsx
@@ -5,6 +5,8 @@ import { ServiceMetadata } from "io-functions-commons/dist/generated/definitions
 import { ServiceScopeEnum } from "io-functions-commons/dist/generated/definitions/ServiceScope";
 
 import { WithNamespaces, withNamespaces } from "react-i18next";
+import { LIMITS } from "../../utils/constants";
+import MetadataDescriptionEditor from "./MetadataDescriptionEditor";
 
 type OwnProps = {
   service_metadata?: ServiceMetadata;
@@ -13,6 +15,8 @@ type OwnProps = {
 };
 
 type Props = WithNamespaces & OwnProps;
+
+const { MARKDOWN } = LIMITS;
 
 /**
  * Array containing all keys of ServiceMetadata, and for each of them an input is created inside the form.
@@ -23,6 +27,10 @@ export const MetadataKeys = ServiceMetadata.type.types.reduce(
   [] as readonly string[]
 );
 
+const InputTextMetadataKeys = MetadataKeys.filter(
+  k => k !== "scope" && k !== "description"
+);
+
 const MetadataInput = ({
   service_metadata,
   onChange,
@@ -30,9 +38,22 @@ const MetadataInput = ({
   t
 }: Props) => {
   return isApiAdmin ? (
-    // All input text Metadata (except 'scope' that is an enumeration)
+    /* - Input text: all metadata except 'scope' and 'descrition'
+     * - Text area: 'descrition' according to MetadataDescritionEditor
+     * - Select: 'scope' that is an enumeration
+     */
     <div>
-      {MetadataKeys.filter(k => k !== "scope").map((k, i) => (
+      <MetadataDescriptionEditor
+        markdown={
+          service_metadata && service_metadata.description
+            ? service_metadata.description
+            : ""
+        }
+        markdownLength={[MARKDOWN.MIN, MARKDOWN.MAX]}
+        isMarkdownValid={true}
+        onChangeMarkdown={onChange}
+      />
+      {InputTextMetadataKeys.map((k, i) => (
         <div key={i}>
           <label className="m-0">{t(k)}</label>
           <input

--- a/src/components/input/__tests__/metadata-keys.test.ts
+++ b/src/components/input/__tests__/metadata-keys.test.ts
@@ -1,9 +1,17 @@
-import { MetadataKeys } from "../MetadataInput";
+import { MetadataKeys, SortedMetadata } from "../MetadataInput";
 
 describe("Metadata keys for subscription update", () => {
   it("should be a valid string array", () => {
     expect(Array.isArray(MetadataKeys)).toBe(true);
     expect(MetadataKeys.length).toBeGreaterThan(0);
     expect(MetadataKeys.every(key => typeof key === "string")).toBe(true);
+  });
+});
+
+describe("Sorted Metadata keys for subscription update", () => {
+  it("should be a valid string array", () => {
+    expect(Array.isArray(SortedMetadata)).toBe(true);
+    expect(SortedMetadata.length).toBeGreaterThan(0);
+    expect(SortedMetadata.every(key => typeof key === "string")).toBe(true);
   });
 });

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -111,7 +111,8 @@ const en = {
     cta: "Cta",
     token_name: "Token Name",
     support_url: "Support Url",
-    scope: "Scope"
+    scope: "Scope",
+    metadata: "Metadata"
   },
   servers: {
     select: "Select your server (endpoint) of choice",

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -111,7 +111,8 @@ const it = {
     cta: "Cta",
     token_name: "Token Name",
     support_url: "Support Url",
-    scope: "Scope"
+    scope: "Scope",
+    metadata: "Metadati"
   },
   servers: {
     select: "Seleziona il server (endpoint) predefinito",

--- a/src/pages/SubscriptionService.tsx
+++ b/src/pages/SubscriptionService.tsx
@@ -83,17 +83,16 @@ class SubscriptionService extends Component<Props, SubscriptionServiceState> {
     const {
       target: { name, value }
     } = event;
+    const inputValue = inputValueMap(name, value);
     Service.decode({
       ...this.state.service,
       service_metadata: {
         ...(this.state.service && this.state.service.service_metadata
           ? this.state.service.service_metadata
           : undefined),
-        [name]: inputValueMap(name, value)
+        [name]: inputValue === "" ? undefined : inputValue
       }
-    })
-      .map(service => this.setState({ service, isValid: true }))
-      .mapLeft(() => this.setState({ isValid: value === "" }));
+    }).map(service => this.setState({ service }));
   };
 
   public handleSubmit = async () => {
@@ -135,105 +134,109 @@ class SubscriptionService extends Component<Props, SubscriptionServiceState> {
               {t("title")} {service.service_id}
             </h4>
             <form className="mb-5 mt-1">
-              <label className="m-0">{t("name")}*</label>
-              <input
-                name="service_name"
-                type="text"
-                defaultValue={service.service_name}
-                onChange={this.handleInputChange}
-                className="mb-4"
-              />
+              <div className="shadow p-4">
+                <label className="m-0">{t("name")}*</label>
+                <input
+                  name="service_name"
+                  type="text"
+                  defaultValue={service.service_name}
+                  onChange={this.handleInputChange}
+                  className="mb-4"
+                />
 
-              <label className="m-0">{t("department")}*</label>
-              <input
-                name="department_name"
-                type="text"
-                defaultValue={service.department_name}
-                onChange={this.handleInputChange}
-                className="mb-4"
-              />
+                <label className="m-0">{t("department")}*</label>
+                <input
+                  name="department_name"
+                  type="text"
+                  defaultValue={service.department_name}
+                  onChange={this.handleInputChange}
+                  className="mb-4"
+                />
 
-              <label className="m-0">{t("organization")}*</label>
-              <input
-                name="organization_name"
-                type="text"
-                defaultValue={service.organization_name}
-                onChange={this.handleInputChange}
-                className="mb-4"
-              />
+                <label className="m-0">{t("organization")}*</label>
+                <input
+                  name="organization_name"
+                  type="text"
+                  defaultValue={service.organization_name}
+                  onChange={this.handleInputChange}
+                  className="mb-4"
+                />
 
-              <label className="m-0">{t("organization_fiscal_code")}*</label>
-              <input
-                name="organization_fiscal_code"
-                type="text"
-                defaultValue={service.organization_fiscal_code}
-                onChange={this.handleInputChange}
-                className="mb-4"
-              />
+                <label className="m-0">{t("organization_fiscal_code")}*</label>
+                <input
+                  name="organization_fiscal_code"
+                  type="text"
+                  defaultValue={service.organization_fiscal_code}
+                  onChange={this.handleInputChange}
+                  className="mb-4"
+                />
 
-              {storage.isApiAdmin && (
-                <div>
-                  <label className="m-0">
-                    {t("max_allowed_payment_amount")}
-                  </label>
-                  <input
-                    name="max_allowed_payment_amount"
-                    type="text"
-                    defaultValue={
-                      service.max_allowed_payment_amount
-                        ? service.max_allowed_payment_amount.toString()
-                        : undefined
-                    }
-                    onChange={this.handleInputChange}
-                    className="mb-4"
-                  />
-                </div>
-              )}
+                {storage.isApiAdmin && (
+                  <div>
+                    <label className="m-0">
+                      {t("max_allowed_payment_amount")}
+                    </label>
+                    <input
+                      name="max_allowed_payment_amount"
+                      type="text"
+                      defaultValue={
+                        service.max_allowed_payment_amount
+                          ? service.max_allowed_payment_amount.toString()
+                          : undefined
+                      }
+                      onChange={this.handleInputChange}
+                      className="mb-4"
+                    />
+                  </div>
+                )}
 
-              {storage.isApiAdmin && (
-                <div>
-                  <label className="m-0">{t("authorized_ips")}</label>
-                  <input
-                    name="authorized_cidrs"
-                    type="text"
-                    defaultValue={service.authorized_cidrs.join(";")}
-                    onChange={this.handleInputChange}
-                    className="mb-4"
-                  />
-                </div>
-              )}
+                {storage.isApiAdmin && (
+                  <div>
+                    <label className="m-0">{t("authorized_ips")}</label>
+                    <input
+                      name="authorized_cidrs"
+                      type="text"
+                      defaultValue={service.authorized_cidrs.join(";")}
+                      onChange={this.handleInputChange}
+                      className="mb-4"
+                    />
+                  </div>
+                )}
 
-              {storage.isApiAdmin && (
-                <div>
-                  <label className="m-0">{t("authorized_recipients")}*</label>
-                  <input
-                    name="authorized_recipients"
-                    type="text"
-                    defaultValue={service.authorized_recipients.join(";")}
-                    onChange={this.handleInputChange}
-                    className="mb-4"
-                  />
-                </div>
-              )}
+                {storage.isApiAdmin && (
+                  <div>
+                    <label className="m-0">{t("authorized_recipients")}*</label>
+                    <input
+                      name="authorized_recipients"
+                      type="text"
+                      defaultValue={service.authorized_recipients.join(";")}
+                      onChange={this.handleInputChange}
+                      className="mb-4"
+                    />
+                  </div>
+                )}
 
-              <MetadataInput
-                onChange={this.handleMetadataChange}
-                service_metadata={service.service_metadata}
-                isApiAdmin={storage.isApiAdmin}
-              />
-
-              {storage.isApiAdmin && (
-                <div>
-                  <input
-                    name="is_visible"
-                    type="checkbox"
-                    defaultChecked={service.is_visible}
-                    onChange={this.handleInputChange}
-                    className="mb-4 mr-2"
-                  />
-                  <label className="m-0">{t("visible_service")}</label>
-                </div>
-              )}
+                {storage.isApiAdmin && (
+                  <div>
+                    <input
+                      name="is_visible"
+                      type="checkbox"
+                      defaultChecked={service.is_visible}
+                      onChange={this.handleInputChange}
+                      className="mb-4 mr-2"
+                    />
+                    <label className="m-0">{t("visible_service")}</label>
+                  </div>
+                )}
+              </div>
+              <div className="shadow p-4">
+                <h5>Metadata</h5>
+                <MetadataInput
+                  onChange={this.handleMetadataChange}
+                  service_metadata={service.service_metadata}
+                  isApiAdmin={storage.isApiAdmin}
+                />
+              </div>
 
               <Button
                 color="primary"


### PR DESCRIPTION
This PR introduces:
- a new component to handle metadata description as markdown syntax;
- a mock for css in jest test; 

<img width="1787" alt="Schermata 2020-10-23 alle 15 41 25" src="https://user-images.githubusercontent.com/52280205/97011325-d3308b00-1546-11eb-8305-bfd832f816ac.png">

<img width="1787" alt="Schermata 2020-10-23 alle 15 40 33" src="https://user-images.githubusercontent.com/52280205/97011342-d7f53f00-1546-11eb-9791-9ddab64c893b.png">
