### PR TITLE
[#175915737] Add markdown editor for cta metadata field

### DIFF
--- a/src/components/input/MarkdownEditor.css
+++ b/src/components/input/MarkdownEditor.css
@@ -1,0 +1,4 @@
+.editor--message--preview
+{
+    overflow-y: auto;
+}

--- a/src/components/input/MarkdownEditor.tsx
+++ b/src/components/input/MarkdownEditor.tsx
@@ -7,20 +7,21 @@ import ReactMarkdown, { NodeType } from "react-markdown";
 import { LIMITS } from "../../utils/constants";
 const { MARKDOWN } = LIMITS;
 
-import "./MetadataDescriptionEditor.css";
+import "./MarkdownEditor.css";
 
 type OwnProps = {
   markdown: string;
   // tslint:disable-next-line:readonly-array
   markdownLength: Readonly<[number, number]>;
+  name: string;
   isMarkdownValid: boolean;
   onChangeMarkdown: (event: ChangeEvent<HTMLInputElement>) => void;
 };
 type Props = WithNamespaces & OwnProps;
 
-class MetadataDescriptionEditor extends Component<Props, never> {
+class MarkdownEditor extends Component<Props, never> {
   public render() {
-    const { markdown, t } = this.props;
+    const { markdown, name, t } = this.props;
     const { onChangeMarkdown } = this.props;
     // tslint:disable-next-line:readonly-array
     const allowedTypes: NodeType[] = [
@@ -53,11 +54,11 @@ class MetadataDescriptionEditor extends Component<Props, never> {
     return (
       <section className="pages--container">
         <section className="h-90 d-flex flex-column">
-          <label className="m-0">{t("description")}</label>
+          <label className="m-0">{t(name)}</label>
           <section className="h-100 flex-1 d-flex flex-row">
             <section className="flex-1 h-100">
               <Input
-                name="description"
+                name={name}
                 className="h-100 font-weight-normal"
                 type="textarea"
                 value={markdown}
@@ -67,7 +68,7 @@ class MetadataDescriptionEditor extends Component<Props, never> {
               />
             </section>
             <ReactMarkdown
-              className="description-editor--message--preview form-control card shadow h-100 flex-1"
+              className="editor--message--preview form-control card shadow h-100 flex-1"
               source={markdown}
               unwrapDisallowed={true}
               allowedTypes={allowedTypes}
@@ -79,4 +80,4 @@ class MetadataDescriptionEditor extends Component<Props, never> {
   }
 }
 
-export default withNamespaces(["service"])(MetadataDescriptionEditor);
+export default withNamespaces(["service"])(MarkdownEditor);

--- a/src/components/input/MetadataDescriptionEditor.css
+++ b/src/components/input/MetadataDescriptionEditor.css
@@ -1,4 +1,0 @@
-.description-editor--message--preview
-{
-    overflow-y: auto;
-}

--- a/src/components/input/MetadataInput.tsx
+++ b/src/components/input/MetadataInput.tsx
@@ -43,7 +43,7 @@ const MetadataInput = ({
 }: Props) => {
   return isApiAdmin ? (
     /* - Input text: all metadata except 'scope', 'descrition' and 'cta'
-     * - Text area: 'descrition' and 'cta' according to MarkdownEditor
+     * - Text area: 'descrition' according to MarkdownEditor and 'cta' as a simple text area
      * - Select: 'scope' that is an enumeration
      */
     <div>

--- a/src/components/input/MetadataInput.tsx
+++ b/src/components/input/MetadataInput.tsx
@@ -6,7 +6,7 @@ import { ServiceScopeEnum } from "io-functions-commons/dist/generated/definition
 
 import { WithNamespaces, withNamespaces } from "react-i18next";
 import { LIMITS } from "../../utils/constants";
-import MetadataDescriptionEditor from "./MetadataDescriptionEditor";
+import MarkdownEditor from "./MarkdownEditor";
 
 type OwnProps = {
   service_metadata?: ServiceMetadata;
@@ -29,7 +29,8 @@ export const MetadataKeys = ServiceMetadata.type.types.reduce(
 
 export const SortedMetadata: readonly string[] = [
   "description",
-  ...MetadataKeys.filter(k => k !== "description" && k !== "scope"),
+  "cta",
+  ...MetadataKeys.filter(k => !["description", "scope", "cta"].includes(k)),
   "scope"
 ];
 
@@ -40,8 +41,8 @@ const MetadataInput = ({
   t
 }: Props) => {
   return isApiAdmin ? (
-    /* - Input text: all metadata except 'scope' and 'descrition'
-     * - Text area: 'descrition' according to MetadataDescritionEditor
+    /* - Input text: all metadata except 'scope', 'descrition' and 'cta'
+     * - Text area: 'descrition' and 'cta' according to MarkdownEditor
      * - Select: 'scope' that is an enumeration
      */
     <div>
@@ -70,12 +71,26 @@ const MetadataInput = ({
             </select>
           </div>
         ) : k === "description" ? (
-          <MetadataDescriptionEditor
+          <MarkdownEditor
             markdown={
               service_metadata && service_metadata.description
                 ? service_metadata.description
                 : ""
             }
+            name="description"
+            markdownLength={[MARKDOWN.MIN, MARKDOWN.MAX]}
+            isMarkdownValid={true}
+            onChangeMarkdown={onChange}
+            key={i}
+          />
+        ) : k === "cta" ? (
+          <MarkdownEditor
+            markdown={
+              service_metadata && service_metadata.cta
+                ? service_metadata.cta
+                : ""
+            }
+            name="cta"
             markdownLength={[MARKDOWN.MIN, MARKDOWN.MAX]}
             isMarkdownValid={true}
             onChangeMarkdown={onChange}

--- a/src/components/input/MetadataInput.tsx
+++ b/src/components/input/MetadataInput.tsx
@@ -5,6 +5,7 @@ import { ServiceMetadata } from "io-functions-commons/dist/generated/definitions
 import { ServiceScopeEnum } from "io-functions-commons/dist/generated/definitions/ServiceScope";
 
 import { WithNamespaces, withNamespaces } from "react-i18next";
+import { Input } from "reactstrap";
 import { LIMITS } from "../../utils/constants";
 import MarkdownEditor from "./MarkdownEditor";
 
@@ -84,18 +85,21 @@ const MetadataInput = ({
             key={i}
           />
         ) : k === "cta" ? (
-          <MarkdownEditor
-            markdown={
-              service_metadata && service_metadata.cta
-                ? service_metadata.cta
-                : ""
-            }
-            name="cta"
-            markdownLength={[MARKDOWN.MIN, MARKDOWN.MAX]}
-            isMarkdownValid={true}
-            onChangeMarkdown={onChange}
-            key={i}
-          />
+          <div key={i}>
+            <label className="m-0">{t(k)}</label>
+            <Input
+              defaultValue={
+                service_metadata && service_metadata.cta
+                  ? service_metadata.cta
+                  : ""
+              }
+              onChange={onChange}
+              name={k}
+              type="textarea"
+              rows="15"
+              className="mb-4 h-100 flex-row"
+            />
+          </div>
         ) : (
           <div key={i}>
             <label className="m-0">{t(k)}</label>


### PR DESCRIPTION
<img width="1358" alt="Schermata 2020-11-30 alle 13 00 34" src="https://user-images.githubusercontent.com/52280205/100608739-24355b00-330d-11eb-99d0-834f445ea641.png">
