### PR TITLE
[#176069616] Disable checkout in deploy stage

### DIFF
--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -122,7 +122,9 @@ stages:
       - Prepare_artifact
     jobs:
       - job: 'deploy_to_container'       
-        steps:  
+        steps:
+          - checkout: none
+            
           - download: current
             artifact: Bundle
 

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -103,7 +103,9 @@ stages:
       - Prepare_artifact
     jobs:
       - job: 'deploy_to_container'       
-        steps:  
+        steps:
+          - checkout: none
+  
           - download: current
             artifact: Bundle
 
@@ -124,7 +126,7 @@ stages:
       - job: 'deploy_to_container'       
         steps:
           - checkout: none
-            
+
           - download: current
             artifact: Bundle
 


### PR DESCRIPTION
This PR disables the _git checkout_ for the deploy stage, in order to avoid copying the code to the storage.