### PR TITLE
[#176014693] Rename pipeline vars - purge cdn

### DIFF
--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -145,5 +145,5 @@ stages:
               azureSubscription: '$(PRODUCTION_AZURE_SUBSCRIPTION)'
               scriptLocation: inlineScript
               inlineScript: |
-                call az cdn endpoint purge -g $(RESOURCE_GROUP_AZURE) -n $(ENDPOINT_AZURE) --profile-name $(PROFILE_NAME_CDN_AZURE) --content-paths "/*"
+                call az cdn endpoint purge -g $(PRODUCTION_RESOURCE_GROUP_NAME) -n $(PRODUCTION_CDN_ENDPOINT) --profile-name $(PRODUCTION_CDN_PROFILE_NAME) --content-paths "/*"
                 


### PR DESCRIPTION
### Description

This PR correctly renames the variables used in ci/cd step _purge cdn_:

- RESOURCE_GROUP_AZURE  --> PRODUCTION_RESOURCE_GROUP_NAME;
- ENDPOINT_AZURE --> PRODUCTION_CDN_ENDPOINT;
- PROFILE_NAME_CDN_AZURE --> PRODUCTION_CDN_PROFILE_NAME.