### PR TITLE
[#ENTE-36] User can edit service metadata fields

### DIFF
--- a/src/components/input/MetadataInput.tsx
+++ b/src/components/input/MetadataInput.tsx
@@ -12,6 +12,7 @@ import MarkdownEditor from "./MarkdownEditor";
 type OwnProps = {
   service_metadata?: ServiceMetadata;
   isApiAdmin: boolean;
+  originalServiceIsVisible: boolean;
   onChange: (event: ChangeEvent<HTMLSelectElement | HTMLInputElement>) => void;
 };
 
@@ -31,7 +32,10 @@ export const MetadataKeys = ServiceMetadata.type.types.reduce(
 export const SortedMetadata: readonly string[] = [
   "description",
   "cta",
-  ...MetadataKeys.filter(k => !["description", "scope", "cta"].includes(k)),
+  ...MetadataKeys.filter(
+    k => !["description", "scope", "cta", "token_name"].includes(k)
+  ),
+  "token_name",
   "scope"
 ];
 
@@ -39,9 +43,10 @@ const MetadataInput = ({
   service_metadata,
   onChange,
   isApiAdmin,
+  originalServiceIsVisible,
   t
 }: Props) => {
-  return isApiAdmin ? (
+  return (
     /* - Input text: all metadata except 'scope', 'descrition' and 'cta'
      * - Text area: 'descrition' according to MarkdownEditor and 'cta' as a simple text area
      * - Select: 'scope' that is an enumeration
@@ -56,6 +61,7 @@ const MetadataInput = ({
               value={service_metadata ? service_metadata.scope : undefined}
               className="form-control mb-4"
               onChange={onChange}
+              disabled={originalServiceIsVisible && !isApiAdmin}
             >
               <option
                 key={ServiceScopeEnum.NATIONAL}
@@ -100,6 +106,18 @@ const MetadataInput = ({
               className="mb-4 h-100 flex-row"
             />
           </div>
+        ) : k === "token_name" ? (
+          <div key={i}>
+            <label className="m-0">{t(k)}</label>
+            <input
+              name={k}
+              type="text"
+              defaultValue={Object(service_metadata)[k]}
+              onChange={onChange}
+              className="mb-4"
+              disabled={!isApiAdmin}
+            />
+          </div>
         ) : (
           <div key={i}>
             <label className="m-0">{t(k)}</label>
@@ -114,7 +132,7 @@ const MetadataInput = ({
         )
       )}
     </div>
-  ) : null;
+  );
 };
 
 export default withNamespaces("service")(MetadataInput);

--- a/src/pages/SubscriptionService.tsx
+++ b/src/pages/SubscriptionService.tsx
@@ -54,6 +54,7 @@ type SubscriptionServiceState = {
   logo?: string;
   logoIsValid: boolean;
   logoUploaded: boolean;
+  originalIsVisible?: boolean;
 };
 
 function inputValueMap(name: string, value: string | boolean) {
@@ -81,7 +82,8 @@ class SubscriptionService extends Component<Props, SubscriptionServiceState> {
     isValid: true,
     logo: undefined,
     logoIsValid: true,
-    logoUploaded: true
+    logoUploaded: true,
+    originalIsVisible: undefined
   };
 
   public async componentDidMount() {
@@ -98,7 +100,8 @@ class SubscriptionService extends Component<Props, SubscriptionServiceState> {
     };
 
     this.setState({
-      service
+      service,
+      originalIsVisible: serviceFromBackend.is_visible
     });
   }
 
@@ -228,7 +231,8 @@ class SubscriptionService extends Component<Props, SubscriptionServiceState> {
       isValid,
       logo,
       logoIsValid,
-      logoUploaded
+      logoUploaded,
+      originalIsVisible
     } = this.state;
     const { t } = this.props;
 
@@ -297,18 +301,16 @@ class SubscriptionService extends Component<Props, SubscriptionServiceState> {
                   </div>
                 )}
 
-                {storage.isApiAdmin && (
-                  <div>
-                    <label className="m-0">{t("authorized_ips")}</label>
-                    <input
-                      name="authorized_cidrs"
-                      type="text"
-                      defaultValue={service.authorized_cidrs.join(";")}
-                      onChange={this.handleInputChange}
-                      className="mb-4"
-                    />
-                  </div>
-                )}
+                <div>
+                  <label className="m-0">{t("authorized_ips")}</label>
+                  <input
+                    name="authorized_cidrs"
+                    type="text"
+                    defaultValue={service.authorized_cidrs.join(";")}
+                    onChange={this.handleInputChange}
+                    className="mb-4"
+                  />
+                </div>
 
                 {storage.isApiAdmin && (
                   <div>
@@ -337,34 +339,32 @@ class SubscriptionService extends Component<Props, SubscriptionServiceState> {
                 )}
               </div>
 
-              {storage.isApiAdmin && (
-                <div className="shadow p-4">
-                  <h5>{t("service_logo")}</h5>
-                  <UploadLogo
-                    errorLogoUpload={errorLogoUpload}
-                    isSubmitEnabled={logo !== undefined && logoIsValid}
-                    isValid={logoIsValid}
-                    logoPath={`${SERVICES_LOGO_PATH}${service.service_id.toLowerCase()}.png`}
-                    logoUploaded={logoUploaded}
-                    nameButton="service_logo_upload"
-                    nameInput="service_logo"
-                    onChangeHandler={this.handleServiceLogoChange}
-                    onError={this.handleOnErrorImage}
-                    onSubmitHandler={this.handleServiceLogoSubmit}
-                  />
-                </div>
-              )}
+              <div className="shadow p-4">
+                <h5>{t("service_logo")}</h5>
+                <UploadLogo
+                  errorLogoUpload={errorLogoUpload}
+                  isSubmitEnabled={logo !== undefined && logoIsValid}
+                  isValid={logoIsValid}
+                  logoPath={`${SERVICES_LOGO_PATH}${service.service_id.toLowerCase()}.png`}
+                  logoUploaded={logoUploaded}
+                  nameButton="service_logo_upload"
+                  nameInput="service_logo"
+                  onChangeHandler={this.handleServiceLogoChange}
+                  onError={this.handleOnErrorImage}
+                  onSubmitHandler={this.handleServiceLogoSubmit}
+                />
+              </div>
 
-              {storage.isApiAdmin && (
-                <div className="shadow p-4">
-                  <h5>Metadata</h5>
-                  <MetadataInput
-                    onChange={this.handleMetadataChange}
-                    service_metadata={service.service_metadata}
-                    isApiAdmin={storage.isApiAdmin}
-                  />
-                </div>
-              )}
+              <div className="shadow p-4">
+                <h5>Metadata</h5>
+                <MetadataInput
+                  onChange={this.handleMetadataChange}
+                  service_metadata={service.service_metadata}
+                  isApiAdmin={storage.isApiAdmin}
+                  originalServiceIsVisible={originalIsVisible || false}
+                />
+              </div>
+
               <Button
                 color="primary"
                 disabled={!isValid}


### PR DESCRIPTION
#### List of Changes
- User can edit authorized IP (`authorized_cidrs`) and Service Logo and service metadata without:
  - `token_name`
  - `is_visible`
  - `max_payment_allowed`
  - `authorized_recipients`
  - `scope` for visible services

#### Motivation and Context
A limited user should update `service_metadata` and `authorized_cidrs` to reduce the workload for Admins to fix wrong or missing information.

#### How Has This Been Tested?
- no test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)