### PR TITLE
[#Ente-72] Fix for a missing web_url form field

### DIFF
--- a/src/components/input/MetadataInput.tsx
+++ b/src/components/input/MetadataInput.tsx
@@ -66,9 +66,13 @@ const MetadataInput = ({
   );
 
   const otherfields = MetadataKeys.filter(
-    elem => elem === "app_ios" || elem === "app_android" || elem === "address"
+    elem =>
+      elem === "app_ios" ||
+      elem === "app_android" ||
+      elem === "web_url" ||
+      elem === "address"
   );
-  // privacy_url*, tos_url, ios_url, android_url, address
+
   const secondaryFields = MetadataKeys.filter(
     elem => elem === "tos_url" || elem === "privacy_url"
   ).sort();


### PR DESCRIPTION
With this PR I'll fix a missing field `web_url` inside the service metadata form.