### PR TITLE
[#Ente-125] Properties to be validated by an Admin now are grouped to…

### DIFF
--- a/src/components/input/AdminFields.tsx
+++ b/src/components/input/AdminFields.tsx
@@ -1,0 +1,103 @@
+import { Service } from "io-functions-commons/dist/generated/definitions/Service";
+import { ServiceScopeEnum } from "io-functions-commons/dist/generated/definitions/ServiceScope";
+
+import React, { ChangeEvent, FocusEvent } from "react";
+import { WithNamespaces, withNamespaces } from "react-i18next";
+
+type OwnProps = {
+  service: Service;
+  isApiAdmin: boolean;
+  showError: boolean;
+  errors: Record<string, string>;
+  onChange: (event: ChangeEvent<HTMLSelectElement | HTMLInputElement>) => void;
+  onBlur: (
+    prop: keyof Service
+  ) => (event: FocusEvent<HTMLInputElement>) => void;
+};
+
+type Props = WithNamespaces & OwnProps;
+
+const AdminFields = ({
+  service,
+  onChange,
+  onBlur,
+  isApiAdmin,
+  errors,
+  t
+}: Props) => {
+  const renderFields = () => {
+    const scope = service.service_metadata
+      ? service.service_metadata.scope
+      : undefined;
+    return (
+      <React.Fragment>
+        <div>
+          <label className="m-0">{t("scope")}*</label>
+          <select
+            style={{
+              border:
+                scope !== undefined && scope === "NATIONAL"
+                  ? "2px solid #FF7F50"
+                  : "2px solid #7FFFD4"
+            }}
+            name="scope"
+            value={scope}
+            className="form-control mb-4"
+            disabled={service.is_visible && !isApiAdmin}
+            onChange={onChange}
+          >
+            <option
+              key={ServiceScopeEnum.NATIONAL}
+              value={ServiceScopeEnum.NATIONAL}
+            >
+              {t(ServiceScopeEnum.NATIONAL.toLocaleLowerCase())}
+            </option>
+            <option key={ServiceScopeEnum.LOCAL} value={ServiceScopeEnum.LOCAL}>
+              {t(ServiceScopeEnum.LOCAL.toLocaleLowerCase())}
+            </option>
+          </select>
+        </div>
+        {isApiAdmin && (
+          <div>
+            <label
+              className={
+                errors[`max_allowed_payment_amount`] ? "mb0 error-text" : "mb0"
+              }
+            >
+              {t("max_allowed_payment_amount")}
+            </label>
+            <input
+              name="max_allowed_payment_amount"
+              type="text"
+              defaultValue={
+                service.max_allowed_payment_amount
+                  ? service.max_allowed_payment_amount.toString()
+                  : undefined
+              }
+              onBlur={onBlur("max_allowed_payment_amount")}
+              className={
+                errors[`max_allowed_payment_amount`] ? "mb4 error" : "mb4"
+              }
+            />
+          </div>
+        )}
+        {isApiAdmin && (
+          <div className="mt-5">
+            <input
+              name="is_visible"
+              type="checkbox"
+              defaultChecked={service.is_visible}
+              onChange={onChange}
+              className="mb-4 mr-2"
+            />
+            <label className="m-0">{t("visible_service")}</label>
+          </div>
+        )}
+      </React.Fragment>
+    );
+  };
+
+  return <React.Fragment>{renderFields()}</React.Fragment>;
+};
+
+export default withNamespaces("service")(AdminFields);

--- a/src/components/input/SecurityFields.tsx
+++ b/src/components/input/SecurityFields.tsx
@@ -1,6 +1,6 @@
 import { Service } from "io-functions-commons/dist/generated/definitions/Service";
 
-import React, { ChangeEvent, FocusEvent } from "react";
+import React, { FocusEvent } from "react";
 import { WithNamespaces, withNamespaces } from "react-i18next";
 
 type OwnProps = {
@@ -8,7 +8,6 @@ type OwnProps = {
   isApiAdmin: boolean;
   showError: boolean;
   errors: Record<string, string>;
-  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onBlur: (
     prop: keyof Service
   ) => (event: FocusEvent<HTMLInputElement>) => void;
@@ -16,14 +15,7 @@ type OwnProps = {
 
 type Props = WithNamespaces & OwnProps;
 
-const SecurityFields = ({
-  service,
-  onChange,
-  onBlur,
-  isApiAdmin,
-  errors,
-  t
-}: Props) => {
+const SecurityFields = ({ service, onBlur, isApiAdmin, errors, t }: Props) => {
   const renderFields = () => {
     return (
       <React.Fragment>
@@ -60,42 +52,6 @@ const SecurityFields = ({
               onBlur={onBlur("authorized_recipients")}
               className={errors[`authorized_recipients`] ? "mb4 error" : "mb4"}
             />
-          </div>
-        )}
-        {isApiAdmin && (
-          <div>
-            <label
-              className={
-                errors[`max_allowed_payment_amount`] ? "mb0 error-text" : "mb0"
-              }
-            >
-              {t("max_allowed_payment_amount")}
-            </label>
-            <input
-              name="max_allowed_payment_amount"
-              type="text"
-              defaultValue={
-                service.max_allowed_payment_amount
-                  ? service.max_allowed_payment_amount.toString()
-                  : undefined
-              }
-              onBlur={onBlur("max_allowed_payment_amount")}
-              className={
-                errors[`max_allowed_payment_amount`] ? "mb4 error" : "mb4"
-              }
-            />
-          </div>
-        )}
-        {isApiAdmin && (
-          <div>
-            <input
-              name="is_visible"
-              type="checkbox"
-              defaultChecked={service.is_visible}
-              onChange={onChange}
-              className="mb-4 mr-2"
-            />
-            <label className="m-0">{t("visible_service")}</label>
           </div>
         )}
       </React.Fragment>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -186,7 +186,9 @@ const en = {
     deactive_service_title: "Deactivating",
     deactive_service_message:
       "We are working on it, the service will soon be deactivated ",
-    guide: "guide"
+    guide: "guide",
+    admin_properties: "Admin Properties",
+    useful_links: "Useful Links"
   },
   servers: {
     select: "Select your server (endpoint) of choice",

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -185,7 +185,9 @@ const it = {
     deactive_service_title: "In corso di disattivazione",
     deactive_service_message:
       "Ci stiamo lavorando, il servizio verrà presto disattivato",
-    guide: "guida"
+    guide: "guida",
+    admin_properties: "Proprietà Admin",
+    useful_links: "Links Utili"
   },
   servers: {
     select: "Seleziona il server (endpoint) predefinito",

--- a/src/pages/SubscriptionService.tsx
+++ b/src/pages/SubscriptionService.tsx
@@ -11,6 +11,7 @@ import { WithNamespaces, withNamespaces } from "react-i18next";
 import { RouteComponentProps } from "react-router";
 import { CIDR } from "../../generated/definitions/api/CIDR";
 import { ServiceId } from "../../generated/definitions/api/ServiceId";
+import AdminFields from "../components/input/AdminFields";
 import ContactInput from "../components/input/ContactInput";
 import LinkFields from "../components/input/LinkFields";
 import MarkdownEditor from "../components/input/MarkdownEditor";
@@ -809,33 +810,7 @@ class SubscriptionService extends Component<Props, SubscriptionServiceState> {
                     onBlur={this.getHandleMetadataBlur("address")}
                     className="mb-4"
                   />
-                  <div>
-                    <label className="m-0">{t("scope")}*</label>
-                    <select
-                      name="scope"
-                      value={
-                        service.service_metadata
-                          ? service.service_metadata.scope
-                          : undefined
-                      }
-                      className="form-control mb-4"
-                      disabled={service.is_visible && !storage.isApiAdmin}
-                      onChange={this.handleMetadataChange}
-                    >
-                      <option
-                        key={ServiceScopeEnum.NATIONAL}
-                        value={ServiceScopeEnum.NATIONAL}
-                      >
-                        {t(ServiceScopeEnum.NATIONAL.toLocaleLowerCase())}
-                      </option>
-                      <option
-                        key={ServiceScopeEnum.LOCAL}
-                        value={ServiceScopeEnum.LOCAL}
-                      >
-                        {t(ServiceScopeEnum.LOCAL.toLocaleLowerCase())}
-                      </option>
-                    </select>
-                  </div>
+
                   <MarkdownEditor
                     markdown={
                       service.service_metadata &&
@@ -857,7 +832,7 @@ class SubscriptionService extends Component<Props, SubscriptionServiceState> {
 
               <form>
                 <div className="card-service p-4 my-4">
-                  <h5 className="my-4">Link Utili</h5>
+                  <h5 className="my-4">{t("useful_links")}</h5>
                   <LinkFields
                     onChange={this.handleMetadataChange}
                     onBlur={this.getHandleMetadataBlur}
@@ -899,8 +874,21 @@ class SubscriptionService extends Component<Props, SubscriptionServiceState> {
                 <div className="card-service p-4 my-4">
                   <h5 className="my-4">{t("security_fields")}</h5>
                   <SecurityFields
-                    onChange={this.handleInputChange}
                     onBlur={this.getHandleBlur}
+                    service={service}
+                    isApiAdmin={storage.isApiAdmin}
+                    showError={showError}
+                    errors={errors}
+                  />
+                </div>
+              </form>
+
+              <form>
+                <div className="card-service p-4 my-4">
+                  <h5 className="my-4">{t("admin_properties")}</h5>
+                  <AdminFields
+                    onChange={this.handleMetadataChange}
+                    onBlur={this.getHandleMetadataBlur}
                     service={service}
                     isApiAdmin={storage.isApiAdmin}
                     showError={showError}


### PR DESCRIPTION
This PR move some properties to an Admin fieldset group, so we can be more accurate when validate a service, expecially have a focus on the `scope` property. Also, there's a UI better experience when a scope property is set to `NATIONAL` or `LOCAL` and prevent to save a service as `NATIONAL` instead of `LOCAL`.