### PR TITLE
[#IC-116] Abstract session handling

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,8 +21,8 @@ class Header extends Component<RouteComponentProps, never> {
     const configuration = await getFromBackend<MsalConfig>({
       path: "configuration"
     });
-    
-    session.logout(configuration)
+
+    session.logout(configuration);
   };
 
   public goHome = () => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,16 +13,16 @@ import { MsalConfig } from "../../generated/definitions/backend/MsalConfig";
 import { StorageContext } from "../context/storage";
 import { getFromBackend } from "../utils/backend";
 import { getConfig } from "../utils/config";
-import { getUserAgentApplication } from "../utils/session/msal";
+
+import * as session from "../utils/session";
 
 class Header extends Component<RouteComponentProps, never> {
   public onSignOut = async () => {
     const configuration = await getFromBackend<MsalConfig>({
       path: "configuration"
     });
-    const userAgentApplication = getUserAgentApplication(configuration);
-    sessionStorage.clear();
-    userAgentApplication.logout();
+    
+    session.logout(configuration)
   };
 
   public goHome = () => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,7 +13,7 @@ import { MsalConfig } from "../../generated/definitions/backend/MsalConfig";
 import { StorageContext } from "../context/storage";
 import { getFromBackend } from "../utils/backend";
 import { getConfig } from "../utils/config";
-import { getUserAgentApplication } from "../utils/msal";
+import { getUserAgentApplication } from "../utils/session/msal";
 
 class Header extends Component<RouteComponentProps, never> {
   public onSignOut = async () => {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -7,7 +7,7 @@ import { Alert } from "design-react-kit";
 const { sessionStorage } = window;
 
 import { getFromBackend } from "../utils/backend";
-import { getUserTokenOrRedirect } from "../utils/msal";
+import { getUserTokenOrRedirect } from "../utils/session/msal";
 
 import { MsalConfig } from "../../generated/definitions/backend/MsalConfig";
 import { UserData } from "../../generated/definitions/backend/UserData";

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -7,7 +7,7 @@ import { Alert } from "design-react-kit";
 const { sessionStorage } = window;
 
 import { getFromBackend } from "../utils/backend";
-import { getUserTokenOrRedirect } from "../utils/session/msal";
+import { getSessionOrLogin } from "../utils/session";
 
 import { MsalConfig } from "../../generated/definitions/backend/MsalConfig";
 import { UserData } from "../../generated/definitions/backend/UserData";
@@ -20,7 +20,7 @@ class Login extends Component<WithNamespaces, never> {
       const configuration = await getFromBackend<MsalConfig>({
         path: "configuration"
       });
-      const tokenAndAccount = await getUserTokenOrRedirect(configuration);
+      const tokenAndAccount = await getSessionOrLogin(configuration);
 
       if (tokenAndAccount) {
         console.debug(
@@ -33,7 +33,7 @@ class Login extends Component<WithNamespaces, never> {
         // profile data (email, name, ...)
         sessionStorage.setItem(
           "userData",
-          JSON.stringify(tokenAndAccount.account.idToken)
+          JSON.stringify(tokenAndAccount.userData)
         );
 
         const apimUser = await getFromBackend<UserData>({ path: "user" });

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { isSome } from "fp-ts/lib/Option";
 
 import { WithNamespaces, withNamespaces } from "react-i18next";
 
@@ -20,20 +21,20 @@ class Login extends Component<WithNamespaces, never> {
       const configuration = await getFromBackend<MsalConfig>({
         path: "configuration"
       });
-      const tokenAndAccount = await getSessionOrLogin(configuration);
+      const maybeTokenAndAccount = await getSessionOrLogin(configuration);
 
-      if (tokenAndAccount) {
+      if (isSome(maybeTokenAndAccount)) {
         console.debug(
           "Login::getUserTokenOrRedirect::tokenAndAccount",
-          tokenAndAccount
+          maybeTokenAndAccount
         );
 
         // bearer token to call backend api
-        sessionStorage.setItem("userToken", tokenAndAccount.token);
+        sessionStorage.setItem("userToken", maybeTokenAndAccount.value.token);
         // profile data (email, name, ...)
         sessionStorage.setItem(
           "userData",
-          JSON.stringify(tokenAndAccount.userData)
+          JSON.stringify(maybeTokenAndAccount.value.userData)
         );
 
         const apimUser = await getFromBackend<UserData>({ path: "user" });

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,5 +1,5 @@
-import React, { Component } from "react";
 import { isSome } from "fp-ts/lib/Option";
+import React, { Component } from "react";
 
 import { WithNamespaces, withNamespaces } from "react-i18next";
 

--- a/src/utils/session/index.ts
+++ b/src/utils/session/index.ts
@@ -1,6 +1,6 @@
+import { none, Option, some } from "fp-ts/lib/Option";
 import { MsalConfig } from "../../../generated/definitions/backend/MsalConfig";
 import { getUserAgentApplication, getUserTokenOrRedirect } from "./msal";
-import { some, none, Option } from "fp-ts/lib/Option";
 
 /**
  * The shape of configuration for the current session strategy

--- a/src/utils/session/index.ts
+++ b/src/utils/session/index.ts
@@ -11,7 +11,7 @@ export type LoggedUserData = {};
 /**
  * Clear and invalidates current session data
  *
- * @param configuration 
+ * @param configuration
  * @returns
  */
 export const logout = (configuration: SessionConfig): void => {

--- a/src/utils/session/index.ts
+++ b/src/utils/session/index.ts
@@ -1,0 +1,6 @@
+import { MsalConfig } from "../../../generated/definitions/backend/MsalConfig";
+
+/**
+ * The shape of configuration for the curretn session strategy
+ */
+export type SessionConfig = MsalConfig; // will include more kinds in the future

--- a/src/utils/session/index.ts
+++ b/src/utils/session/index.ts
@@ -1,5 +1,6 @@
 import { MsalConfig } from "../../../generated/definitions/backend/MsalConfig";
 import { getUserAgentApplication, getUserTokenOrRedirect } from "./msal";
+import { some, none, Option } from "fp-ts/lib/Option";
 
 /**
  * The shape of configuration for the current session strategy
@@ -27,14 +28,14 @@ export const logout = (configuration: SessionConfig): void => {
  */
 export const getSessionOrLogin = async (
   configuration: SessionConfig
-): Promise<undefined | { token: string; userData: LoggedUserData }> => {
+): Promise<Option<{ token: string; userData: LoggedUserData }>> => {
   const tokenAndAccount = await getUserTokenOrRedirect(configuration);
 
   if (tokenAndAccount) {
-    return {
+    return some({
       token: tokenAndAccount.token,
       userData: tokenAndAccount.account.idToken
-    };
+    });
   }
-  return undefined;
+  return none;
 };

--- a/src/utils/session/index.ts
+++ b/src/utils/session/index.ts
@@ -1,18 +1,40 @@
 import { MsalConfig } from "../../../generated/definitions/backend/MsalConfig";
-import { getUserAgentApplication } from "./msal";
+import { getUserAgentApplication, getUserTokenOrRedirect } from "./msal";
 
 /**
- * The shape of configuration for the curretn session strategy
+ * The shape of configuration for the current session strategy
  */
 export type SessionConfig = MsalConfig; // will include more kinds in the future
+
+export type LoggedUserData = {};
 
 /**
  * Clear and invalidates current session data
  *
- * @param configuration
+ * @param configuration 
  * @returns
  */
 export const logout = (configuration: SessionConfig): void => {
   sessionStorage.clear();
   return getUserAgentApplication(configuration).logout();
+};
+
+/**
+ * Get session data or redirect to login page
+ *
+ * @param configuration
+ * @returns
+ */
+export const getSessionOrLogin = async (
+  configuration: SessionConfig
+): Promise<undefined | { token: string; userData: LoggedUserData }> => {
+  const tokenAndAccount = await getUserTokenOrRedirect(configuration);
+
+  if (tokenAndAccount) {
+    return {
+      token: tokenAndAccount.token,
+      userData: tokenAndAccount.account.idToken
+    };
+  }
+  return undefined;
 };

--- a/src/utils/session/index.ts
+++ b/src/utils/session/index.ts
@@ -1,6 +1,18 @@
 import { MsalConfig } from "../../../generated/definitions/backend/MsalConfig";
+import { getUserAgentApplication } from "./msal";
 
 /**
  * The shape of configuration for the curretn session strategy
  */
 export type SessionConfig = MsalConfig; // will include more kinds in the future
+
+/**
+ * Clear and invalidates current session data
+ *
+ * @param configuration
+ * @returns
+ */
+export const logout = (configuration: SessionConfig): void => {
+  sessionStorage.clear();
+  return getUserAgentApplication(configuration).logout();
+};

--- a/src/utils/session/msal.ts
+++ b/src/utils/session/msal.ts
@@ -6,7 +6,7 @@
  * Needs a promise polyfill for old browsers.
  */
 import { UserAgentApplication } from "msal";
-import { MsalConfig } from "../../generated/definitions/backend/MsalConfig";
+import { MsalConfig } from "../../../generated/definitions/backend/MsalConfig";
 
 export function getUserAgentApplication(configuration: MsalConfig) {
   return new UserAgentApplication({


### PR DESCRIPTION
This is a refactor that re-arrange session handling, to make it generic and allow for methods other Azure Active Directory to be implemented. No changes in the behavior are meant for this PR.

It pairs what's been done in https://github.com/pagopa/io-developer-portal-backend/pull/144