### PR TITLE
Add no-strict to generate types and some tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "tslint -p . -c tslint.json -t verbose",
     "commons-definitions:clean": "shx rm -rf generated/definitions/commons",
     "commons-definitions:mkdir": "shx mkdir -p generated/definitions/commons",
-    "commons-definitions:generate": "gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-commons/v22.0.1/openapi/index.yaml --out-dir ./generated/definitions/commons",
+    "commons-definitions:generate": "gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-commons/v22.0.1/openapi/index.yaml --out-dir ./generated/definitions/commons --no-strict",
     "api-definitions:clean": "shx rm -rf generated/definitions/api",
     "api-definitions:mkdir": "shx mkdir -p generated/definitions/api",
     "api-definitions:generate": "gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-functions-admin/master/openapi/index.yaml --out-dir generated/definitions/api --no-strict",

--- a/src/utils/__tests__/createMessagecontent.test.ts
+++ b/src/utils/__tests__/createMessagecontent.test.ts
@@ -1,3 +1,4 @@
+import moment from "moment";
 import { createMessageContent } from "../operations";
 
 const messageData = {
@@ -20,12 +21,15 @@ describe("Create Message Content", () => {
   it("should create a message with payment_data", () => {
     const data = mockMessageData();
     const res = createMessageContent(data);
+
     expect(res).not.toBeNull();
     expect(res).toEqual({
       markdown:
         "This is the markdown, it should be at least 80 characters long otherwise you'll got an error.",
       subject: "A test subject",
-      due_date: new Date("2021-10-22T16:00:00.000Z"),
+      due_date: new Date(
+        moment(messageData.dueDate, messageData.dueDateFormat).toISOString()
+      ),
       payment_data: {
         amount: 123,
         notice_number: "000111222333444555",

--- a/src/utils/__tests__/createMessagecontent.test.ts
+++ b/src/utils/__tests__/createMessagecontent.test.ts
@@ -1,0 +1,65 @@
+import { createMessageContent } from "../operations";
+
+const messageData = {
+  message: {
+    subject: "Questo è un messaggio di prova",
+    markdown:
+      "Questo è markdown, deve essere almeno di 80 caratteri altrimenti hai un errore!!"
+  },
+  dueDate: "22/10/2021, 18:00",
+  amount: "123",
+  notice: "000111222333444555",
+  dueDateFormat: "DD/MM/YYYY, HH:mm",
+  invalidAfterDueDate: true
+};
+
+const mockMessageData = jest.fn().mockImplementation(() => {
+  return messageData;
+});
+describe("Create Message Content", () => {
+  it("should create a message with payment_data", () => {
+    const data = mockMessageData();
+    const res = createMessageContent(data);
+    expect(res).not.toBeNull();
+  });
+  it("should create a message without payment_data", () => {
+    const data = mockMessageData.mockImplementationOnce(() => ({
+      message: {
+        subject: "Questo è un messaggio di prova",
+        markdown:
+          "Questo è markdown, deve essere almeno di 80 caratteri altrimenti hai un errore!!"
+      },
+      dueDateFormat: "DD/MM/YYYY, HH:mm"
+    }))();
+    const res = createMessageContent(data);
+    expect(res).not.toBeNull();
+  });
+  it("should throw 'Wrong parameters format' when subject is lesser than 10 characters", () => {
+    const data = mockMessageData.mockImplementationOnce(() => ({
+      message: {
+        subject: "Errato",
+        markdown:
+          "Questo è markdown, deve essere almeno di 80 caratteri altrimenti hai un errore!!"
+      },
+      dueDateFormat: "DD/MM/YYYY, HH:mm"
+    }))();
+
+    expect(() => createMessageContent(data)).toThrowError(
+      "Wrong parameters format"
+    );
+  });
+  it("should throw 'Wrong parameters format' when message is lesser than 80 characters", () => {
+    const data = mockMessageData.mockImplementationOnce(() => ({
+      message: {
+        subject: "Questo è un messaggio di prova",
+        markdown:
+          "Questo è markdown, di meno di 80 caratteri e deve andare in errore!!"
+      },
+      dueDateFormat: "DD/MM/YYYY, HH:mm"
+    }))();
+
+    expect(() => createMessageContent(data)).toThrowError(
+      "Wrong parameters format"
+    );
+  });
+});

--- a/src/utils/__tests__/createMessagecontent.test.ts
+++ b/src/utils/__tests__/createMessagecontent.test.ts
@@ -2,9 +2,9 @@ import { createMessageContent } from "../operations";
 
 const messageData = {
   message: {
-    subject: "Questo è un messaggio di prova",
+    subject: "A test subject",
     markdown:
-      "Questo è markdown, deve essere almeno di 80 caratteri altrimenti hai un errore!!"
+      "This is the markdown, it should be at least 80 characters long otherwise you'll got an error."
   },
   dueDate: "22/10/2021, 18:00",
   amount: "123",
@@ -21,42 +21,59 @@ describe("Create Message Content", () => {
     const data = mockMessageData();
     const res = createMessageContent(data);
     expect(res).not.toBeNull();
+    expect(res).toEqual({
+      markdown:
+        "This is the markdown, it should be at least 80 characters long otherwise you'll got an error.",
+      subject: "A test subject",
+      due_date: new Date("2021-10-22T16:00:00.000Z"),
+      payment_data: {
+        amount: 123,
+        notice_number: "000111222333444555",
+        invalid_after_due_date: true
+      }
+    });
   });
   it("should create a message without payment_data", () => {
     const data = mockMessageData.mockImplementationOnce(() => ({
       message: {
-        subject: "Questo è un messaggio di prova",
+        subject: "A test subject",
         markdown:
-          "Questo è markdown, deve essere almeno di 80 caratteri altrimenti hai un errore!!"
+          "This is the markdown, it should be at least 80 characters long otherwise you'll got an error."
       },
       dueDateFormat: "DD/MM/YYYY, HH:mm"
     }))();
     const res = createMessageContent(data);
     expect(res).not.toBeNull();
+    expect(res).toEqual({
+      markdown:
+        "This is the markdown, it should be at least 80 characters long otherwise you'll got an error.",
+      subject: "A test subject",
+      due_date: undefined
+    });
   });
   it("should throw 'Wrong parameters format' when subject is lesser than 10 characters", () => {
-    const data = mockMessageData.mockImplementationOnce(() => ({
+    const data = {
+      ...messageData,
       message: {
         subject: "Errato",
         markdown:
-          "Questo è markdown, deve essere almeno di 80 caratteri altrimenti hai un errore!!"
-      },
-      dueDateFormat: "DD/MM/YYYY, HH:mm"
-    }))();
+          "This is the markdown, it should be at least 80 characters long otherwise you'll got an error."
+      }
+    };
 
     expect(() => createMessageContent(data)).toThrowError(
       "Wrong parameters format"
     );
   });
+  // tslint:disable-next-line: no-identical-functions
   it("should throw 'Wrong parameters format' when message is lesser than 80 characters", () => {
-    const data = mockMessageData.mockImplementationOnce(() => ({
+    const data = {
+      ...messageData,
       message: {
-        subject: "Questo è un messaggio di prova",
-        markdown:
-          "Questo è markdown, di meno di 80 caratteri e deve andare in errore!!"
-      },
-      dueDateFormat: "DD/MM/YYYY, HH:mm"
-    }))();
+        subject: "A test subject",
+        markdown: "This is the markdown, it lesser than 80 characters long."
+      }
+    };
 
     expect(() => createMessageContent(data)).toThrowError(
       "Wrong parameters format"

--- a/src/utils/__tests__/paymentdata.test.ts
+++ b/src/utils/__tests__/paymentdata.test.ts
@@ -1,0 +1,38 @@
+import { PaymentData } from "../../../generated/definitions/commons/PaymentData";
+
+describe("PaymentData Decode", () => {
+  it("should return an object with payee", () => {
+    const p = {
+      amount: 122,
+      invalid_after_due_date: true,
+      notice_number: "012345678912345678",
+      payee: {
+        fiscal_code: "01234567890"
+      }
+    };
+    const decoded = PaymentData.decode(p);
+
+    expect(decoded.value).toEqual({
+      amount: 122,
+      invalid_after_due_date: true,
+      notice_number: "012345678912345678",
+      payee: {
+        fiscal_code: "01234567890"
+      }
+    });
+  });
+  it("should return an object also without payee", () => {
+    const p = {
+      amount: 122,
+      invalid_after_due_date: false,
+      notice_number: "012345678912345678"
+    };
+    const decoded = PaymentData.decode(p);
+    expect(decoded.isRight()).toBe(true);
+    expect(decoded.value).toEqual({
+      amount: 122,
+      invalid_after_due_date: false,
+      notice_number: "012345678912345678"
+    });
+  });
+});


### PR DESCRIPTION
Add `--no-strict` to generate types in `package.json` to be able to create a valid content message due to prevent a bug with `io-ts` version 1. 