### PR TITLE
[#IC-234] Fix value change on custom_flow_name metadata

### DIFF
--- a/src/components/input/AdminFields.tsx
+++ b/src/components/input/AdminFields.tsx
@@ -16,7 +16,10 @@ type OwnProps = {
     event: ChangeEvent<HTMLSelectElement | HTMLInputElement>
   ) => void;
   onBlur: (
-    prop: keyof Service | keyof SpecialServiceMetadata
+    prop: keyof Service
+  ) => (event: FocusEvent<HTMLInputElement>) => void;
+  onBlurMetadata: (
+    prop: keyof SpecialServiceMetadata
   ) => (event: FocusEvent<HTMLInputElement>) => void;
 };
 
@@ -27,6 +30,7 @@ const AdminFields = ({
   onChange,
   onChangeMetadata,
   onBlur,
+  onBlurMetadata,
   errors,
   t
 }: Props) => {
@@ -94,7 +98,7 @@ const AdminFields = ({
                 ? service.service_metadata.custom_special_flow
                 : undefined
             }
-            onBlur={onBlur("custom_special_flow")}
+            onBlur={onBlurMetadata("custom_special_flow")}
             className="mb4"
           />
         </div>

--- a/src/pages/SubscriptionService.tsx
+++ b/src/pages/SubscriptionService.tsx
@@ -267,9 +267,9 @@ class SubscriptionService extends Component<Props, SubscriptionServiceState> {
     );
   };
 
-  public getHandleBlur = (
-    prop: keyof ServiceMetadata | keyof Service | keyof SpecialServiceMetadata
-  ) => (event: FocusEvent<HTMLInputElement>) => {
+  public getHandleBlur = (prop: keyof Service) => (
+    event: FocusEvent<HTMLInputElement>
+  ) => {
     const target = event.target;
     const inputValue =
       target.type === "checkbox" ? target.checked : target.value;
@@ -284,7 +284,7 @@ class SubscriptionService extends Component<Props, SubscriptionServiceState> {
   };
 
   public getHandleMetadataBlur = (
-    prop: keyof ServiceMetadata | keyof Service
+    prop: keyof ServiceMetadata | keyof SpecialServiceMetadata
   ) => (event: FocusEvent<HTMLSelectElement | HTMLInputElement>) => {
     const {
       target: { name, value }
@@ -928,6 +928,7 @@ class SubscriptionService extends Component<Props, SubscriptionServiceState> {
                     onChange={this.handleInputChange}
                     onChangeMetadata={this.handleMetadataChange}
                     onBlur={this.getHandleBlur}
+                    onBlurMetadata={this.getHandleMetadataBlur}
                     service={service}
                     showError={showError}
                     errors={errors}


### PR DESCRIPTION
The value `custom_flow_name` for `SpecialServices` cannot be set or edit.
The wrong handler was used on input `onBlur` event.

The types are fixed accordingly with the implementation.

**Cheklist:**
- [ ] Test the fix running the portal locally