### PR TITLE
[#IC-321] Migrations delegate list

### DIFF
--- a/src/components/modal/DisableService.tsx
+++ b/src/components/modal/DisableService.tsx
@@ -1,7 +1,7 @@
 import React, { Component, MouseEvent } from "react";
 import { WithNamespaces, withNamespaces } from "react-i18next";
 
-import "./NewService.css";
+import "./Modal.css";
 
 type OwnProps = {
   t: (key: string) => string;

--- a/src/components/modal/Modal.css
+++ b/src/components/modal/Modal.css
@@ -1,3 +1,5 @@
+/* utility classes to render a modal */
+
 .modal-card {
   position: fixed;
   left: 0;

--- a/src/components/modal/NewService.tsx
+++ b/src/components/modal/NewService.tsx
@@ -2,7 +2,7 @@ import { Button } from "design-react-kit";
 import React, { ChangeEvent, Component, MouseEvent } from "react";
 import { WithNamespaces, withNamespaces } from "react-i18next";
 
-import "./NewService.css";
+import "./Modal.css";
 
 type OwnProps = {
   t: (key: string) => string;

--- a/src/components/modal/PublishService.tsx
+++ b/src/components/modal/PublishService.tsx
@@ -1,7 +1,7 @@
 import React, { Component, MouseEvent } from "react";
 import { WithNamespaces, withNamespaces } from "react-i18next";
 
-import "./NewService.css";
+import "./Modal.css";
 
 type OwnProps = {
   t: (key: string) => string;

--- a/src/components/subscription-migrations/DelegateItem.tsx
+++ b/src/components/subscription-migrations/DelegateItem.tsx
@@ -1,0 +1,85 @@
+import React, { Component } from "react";
+import { WithNamespaces, withNamespaces } from "react-i18next";
+
+type Delegate = {
+  sourceName: string;
+  sourceSurname: string;
+  sourceId: string;
+};
+
+// migration status as it matters for this component
+export type MigrationStatus = "done" | "doing" | "todo" | "failed";
+
+const StatusIcon = ({
+  status,
+  t
+}: {
+  status: MigrationStatus;
+  t: (key: string) => string;
+}) => {
+  switch (status) {
+    case "doing":
+      return <>{t("migration_status_doing")}</>;
+    case "done":
+      return <>{t("migration_status_done")}</>;
+    case "failed":
+      return <>{t("migration_status_failed")}</>;
+    case "todo":
+      return <>{t("migration_status_todo")}</>;
+    default:
+      const _: never = status; // exhaustive check
+      return null;
+  }
+};
+
+type OwnProps = {
+  t: (key: string) => string;
+  // exdcuted when an item is selected/unselected
+  onSelectionChange: (id: Delegate["sourceId"], selected: boolean) => void;
+  delegate: Delegate;
+  migrationStatus: MigrationStatus;
+  selected: boolean;
+};
+
+type Props = WithNamespaces & OwnProps;
+
+class DelegateItem extends Component<Props> {
+  public render() {
+    const {
+      t,
+      delegate: { sourceName: name, sourceSurname: surname, sourceId: id },
+      onSelectionChange,
+      migrationStatus,
+      selected
+    } = this.props;
+    const isStatusLoaded = typeof migrationStatus !== "undefined";
+
+    return (
+      <div
+        className="d-flex mt-1"
+        style={{ gap: "10px", cursor: "pointer" }}
+        onClick={() => {
+          this.setState({ selected: !selected });
+          onSelectionChange(id, !selected);
+        }}
+      >
+        <div style={{ minWidth: "1em", flex: 1, flexGrow: 0 }}>
+          <input name="selected" type="checkbox" defaultChecked={selected} />
+        </div>
+        <div style={{ minWidth: "15em" }}>
+          {name} {surname}
+        </div>
+        <div style={{ flex: 1 }}>
+          {isStatusLoaded && (
+            <>
+              <span>
+                <StatusIcon status={migrationStatus} t={t} />
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+    );
+  }
+}
+export default withNamespaces("subscription_migrations")(DelegateItem);

--- a/src/components/subscription-migrations/DelegateItem.tsx
+++ b/src/components/subscription-migrations/DelegateItem.tsx
@@ -53,18 +53,23 @@ class DelegateItem extends Component<Props> {
       selected
     } = this.props;
     const isStatusLoaded = typeof migrationStatus !== "undefined";
+    const isSelectable =
+      migrationStatus === "todo" || migrationStatus === "failed";
 
     return (
-      <div
-        className="d-flex mt-1"
-        style={{ gap: "10px", cursor: "pointer" }}
-        onClick={() => {
-          this.setState({ selected: !selected });
-          onSelectionChange(id, !selected);
-        }}
-      >
+      <div className="d-flex mt-1" style={{ gap: "10px" }}>
         <div style={{ minWidth: "1em", flex: 1, flexGrow: 0 }}>
-          <input name="selected" type="checkbox" defaultChecked={selected} />
+          {isSelectable && (
+            <input
+              name="selected"
+              type="checkbox"
+              defaultChecked={selected}
+              onChange={() => {
+                this.setState({ selected: !selected });
+                onSelectionChange(id, !selected);
+              }}
+            />
+          )}
         </div>
         <div style={{ minWidth: "15em" }}>
           {name} {surname}

--- a/src/components/subscription-migrations/MigrationsPanel.tsx
+++ b/src/components/subscription-migrations/MigrationsPanel.tsx
@@ -5,29 +5,13 @@ import "../modal/Modal.css";
 
 type OwnProps = {
   t: (key: string) => string;
-  show: boolean;
   onClose: (event: MouseEvent) => void;
 };
 
 type Props = WithNamespaces & OwnProps;
 
 class MigrationsPanel extends Component<Props> {
-  public state: {
-    show: boolean;
-  } = {
-    show: false
-  };
-
-  public componentDidMount() {
-    this.setState({
-      show: this.props.show
-    });
-  }
-
   public render() {
-    if (!this.state.show) {
-      return null;
-    }
     const { t } = this.props;
     return (
       <div className="modal-card" onClick={this.props.onClose}>

--- a/src/components/subscription-migrations/MigrationsPanel.tsx
+++ b/src/components/subscription-migrations/MigrationsPanel.tsx
@@ -1,0 +1,57 @@
+import { Button } from "design-react-kit";
+import React, { ChangeEvent, Component, MouseEvent } from "react";
+import { WithNamespaces, withNamespaces } from "react-i18next";
+
+import "../modal/Modal.css";
+
+type OwnProps = {
+  t: (key: string) => string;
+  show: boolean;
+  onClose: (event: MouseEvent) => void;
+};
+
+type Props = WithNamespaces & OwnProps;
+
+class MigrationsPanel extends Component<Props> {
+  public state: {
+    show: boolean;
+  } = {
+    show: false
+  };
+
+  public componentDidMount() {
+    this.setState({
+      show: this.props.show
+    });
+  }
+
+  public render() {
+    if (!this.state.show) {
+      return null;
+    }
+    const { t } = this.props
+    return (
+      <div className="modal-card" onClick={this.props.onClose}>
+        <div
+          className="modal-content"
+          onClick={event => event.stopPropagation()}
+        >
+          <div className="modal-header">
+            <h4 className="modal-title">{t("migrations_panel_title")}</h4>
+          </div>
+          <div className="modal-body">
+            <div>
+              <span>{t("migrations_panel_list_empty")}</span>
+            </div>
+          </div>
+          <div className="modal-footer">
+            <button onClick={this.props.onClose} className="btn btn-primary">
+              {t("close")}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+export default withNamespaces(["subscription_migrations", "modal"])(MigrationsPanel);

--- a/src/components/subscription-migrations/MigrationsPanel.tsx
+++ b/src/components/subscription-migrations/MigrationsPanel.tsx
@@ -1,7 +1,10 @@
+import { get } from "lodash";
 import React, { Component, MouseEvent } from "react";
 import { WithNamespaces, withNamespaces } from "react-i18next";
+import { getFromBackend } from "../../utils/backend";
 
 import "../modal/Modal.css";
+import DelegateItem, { MigrationStatus } from "./DelegateItem";
 
 type OwnProps = {
   t: (key: string) => string;
@@ -10,9 +13,136 @@ type OwnProps = {
 
 type Props = WithNamespaces & OwnProps;
 
-class MigrationsPanel extends Component<Props> {
+type Delegate = {
+  sourceName: string;
+  sourceSurname: string;
+  sourceId: string;
+};
+type DelegateListResponse = {
+  delegates: readonly Delegate[];
+};
+// the shape of the response from getOwnershipClaimStatus remote operation
+type ClaimProcedureStatusResponse = {
+  data: {
+    COMPLETED: number;
+    FAILED: number;
+    INITIAL: number;
+    PROCESSING: number;
+  };
+};
+
+// A single migration, composed by its status and the relative delegate
+type MigrationItem = Delegate & {
+  status: ClaimProcedureStatusResponse["data"];
+};
+
+// An hashmap with all the migrations
+type MigrationRepository = Record<Delegate["sourceId"], MigrationItem>;
+
+// the full migration status report is reduced so that it's ready to be rendered
+const computeMigrationStatus = (
+  status: ClaimProcedureStatusResponse["data"]
+): MigrationStatus => {
+  if (get(status, "FAILED", 0) > 0) {
+    return "failed";
+  }
+  if (get(status, "INITIAL", 0) > 0) {
+    return "todo";
+  }
+  if (get(status, "PROCESSING", 0) > 0) {
+    return "doing";
+  }
+  return "done";
+};
+
+const fetchMigrationStatus = (
+  id: Delegate["sourceId"]
+): Promise<ClaimProcedureStatusResponse["data"]> =>
+  getFromBackend<ClaimProcedureStatusResponse>({
+    path: `subscriptions/migrations/ownership-claims/${id}`
+  }).then(({ data }) => data);
+
+// converts a generic list into a record, using one of the fields as key
+// tslint:disable-next-line: no-any
+const listToRecord = <T extends Record<string, any>, K extends keyof T>(
+  list: readonly T[],
+  key: K
+): Record<T[K], T> => {
+  return list.reduce((p, e) => ({ ...p, [e[key]]: e }), {} as Record<T[K], T>);
+};
+
+type State = {
+  migrations: MigrationRepository;
+  selectedForMigration: ReadonlyArray<Delegate["sourceId"]>;
+};
+class MigrationsPanel extends Component<Props, State> {
+  public async componentDidMount() {
+    // On component mount, fetch all delegates and the status if their migrations
+
+    const { delegates } = await getFromBackend<DelegateListResponse>({
+      path: "/subscriptions/migrations/delegates"
+    });
+
+    const listOfMigrations: readonly MigrationItem[] = await Promise.all(
+      delegates.map(async delegate => ({
+        ...delegate,
+        status: await fetchMigrationStatus(delegate.sourceId)
+      }))
+    );
+
+    this.setState({ migrations: listToRecord(listOfMigrations, "sourceId") });
+  }
+
+  private startMigration() {
+    // TODO: implement migration claim
+    alert(this.props.t("migrations_not_available"));
+  }
+
   public render() {
     const { t } = this.props;
+    const migrations = get(this.state, "migrations");
+    const selectedForMigration = get(
+      this.state,
+      "selectedForMigration",
+      [] as readonly string[]
+    );
+
+    const EmptyDelegateList = () => (
+      <div>
+        <span>{t("migrations_panel_list_empty")}</span>
+      </div>
+    );
+
+    const MigrationList = () => (
+      <>
+        <div>
+          {migrations &&
+            Object.values(migrations).map(d => (
+              <DelegateItem
+                delegate={d}
+                key={d.sourceId}
+                onSelectionChange={(id, selected) => {
+                  if (selected) {
+                    this.setState({
+                      selectedForMigration: [...selectedForMigration, id]
+                    });
+                  } else {
+                    this.setState({
+                      selectedForMigration: selectedForMigration.filter(
+                        e => e !== id
+                      )
+                    });
+                  }
+                }}
+                selected={selectedForMigration.includes(d.sourceId)}
+                migrationStatus={computeMigrationStatus(d.status)}
+              />
+            ))}
+        </div>
+      </>
+    );
+
+    const LoadingMigrationList = () => null;
     return (
       <div className="modal-card" onClick={this.props.onClose}>
         <div
@@ -23,8 +153,22 @@ class MigrationsPanel extends Component<Props> {
             <h4 className="modal-title">{t("migrations_panel_title")}</h4>
           </div>
           <div className="modal-body">
-            <div>
-              <span>{t("migrations_panel_list_empty")}</span>
+            <p className="mb-3">{t("migrations_panel_abstract")}</p>
+            {!migrations ? (
+              <LoadingMigrationList />
+            ) : Object.keys(migrations).length === 0 ? (
+              <EmptyDelegateList />
+            ) : (
+              <MigrationList />
+            )}
+            <div className="d-flex mt-5" style={{ justifyContent: "center" }}>
+              <button
+                className="btn btn-primary"
+                onClick={() => this.startMigration()}
+                disabled={selectedForMigration.length === 0}
+              >
+                {t("migrations_panel_start_migration")}
+              </button>
             </div>
           </div>
           <div className="modal-footer">

--- a/src/components/subscription-migrations/MigrationsPanel.tsx
+++ b/src/components/subscription-migrations/MigrationsPanel.tsx
@@ -1,5 +1,4 @@
-import { Button } from "design-react-kit";
-import React, { ChangeEvent, Component, MouseEvent } from "react";
+import React, { Component, MouseEvent } from "react";
 import { WithNamespaces, withNamespaces } from "react-i18next";
 
 import "../modal/Modal.css";
@@ -29,7 +28,7 @@ class MigrationsPanel extends Component<Props> {
     if (!this.state.show) {
       return null;
     }
-    const { t } = this.props
+    const { t } = this.props;
     return (
       <div className="modal-card" onClick={this.props.onClose}>
         <div
@@ -54,4 +53,6 @@ class MigrationsPanel extends Component<Props> {
     );
   }
 }
-export default withNamespaces(["subscription_migrations", "modal"])(MigrationsPanel);
+export default withNamespaces(["subscription_migrations", "modal"])(
+  MigrationsPanel
+);

--- a/src/components/subscription-migrations/SummaryBox.tsx
+++ b/src/components/subscription-migrations/SummaryBox.tsx
@@ -11,7 +11,7 @@ type Props = WithNamespaces & OwnProps;
 const SummaryBox = ({ onSubmitHandler, t }: Props) => {
   return (
     <div className="">
-      <div className="" >
+      <div className="">
         <h4>{t("migrations_summary_title")}</h4>
       </div>
 
@@ -22,12 +22,10 @@ const SummaryBox = ({ onSubmitHandler, t }: Props) => {
       </div>
 
       <div className="mt-4">
-        <span className="pt-4 pb-4">
-          {t("disclaimer")}
-        </span>
+        <span className="pt-4 pb-4">{t("disclaimer")}</span>
       </div>
 
-      <div className="mt-4" >
+      <div className="mt-4">
         <h4>{t("migrations_summary_latest")}</h4>
       </div>
 

--- a/src/components/subscription-migrations/SummaryBox.tsx
+++ b/src/components/subscription-migrations/SummaryBox.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+import { WithNamespaces, withNamespaces } from "react-i18next";
+
+type OwnProps = {
+  onSubmitHandler: () => void;
+};
+
+type Props = WithNamespaces & OwnProps;
+
+const SummaryBox = ({ onSubmitHandler, t }: Props) => {
+  return (
+    <div className="">
+      <div className="" >
+        <h4>{t("migrations_summary_title")}</h4>
+      </div>
+
+      <div className="mt-3">
+        <button className="btn btn-primary" onClick={onSubmitHandler}>
+          {t("open_migrations_panel")}
+        </button>
+      </div>
+
+      <div className="mt-4">
+        <span className="pt-4 pb-4">
+          {t("disclaimer")}
+        </span>
+      </div>
+
+      <div className="mt-4" >
+        <h4>{t("migrations_summary_latest")}</h4>
+      </div>
+
+      <div className="mt-3">
+        <span className="pt-3 pb-3">
+          {t("migrations_summary_latest_empty")}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default withNamespaces("subscription_migrations")(SummaryBox);

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -208,7 +208,14 @@ const en = {
     migrations_summary_latest: "Import status",
     migrations_summary_latest_empty: "No import has been started yet",
     disclaimer:
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. In non mauris enim. Aenean pellentesque tristique elit sed pulvinar. Non verranno importati i profili dei delegati associati ai servizi che stai importando, ma solo i servizi stessi. Per tanto, una volta importati i servizi, i/il Referente/i Amministrativo/i associati a App IO dovranno aggiungere i delegati associati al prodotto nell’apposita sezione Referenti."
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. In non mauris enim. Aenean pellentesque tristique elit sed pulvinar. Non verranno importati i profili dei delegati associati ai servizi che stai importando, ma solo i servizi stessi. Per tanto, una volta importati i servizi, i/il Referente/i Amministrativo/i associati a App IO dovranno aggiungere i delegati associati al prodotto nell’apposita sezione Referenti.",
+    migrations_panel_title: "Import Services",
+    migrations_panel_abstract:
+      "Here you will find the delegates who work on the services associated with your organization. To import, select the delegates you want to import / services added for each delegate",
+    migrations_panel_list: "List of delegates who work for your organization",
+    migrations_panel_list_empty:
+      "There are no delegates working for your organization",
+    close: "Close"
   },
   templates: {
     edit: "Edit",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -215,7 +215,12 @@ const en = {
     migrations_panel_list: "List of delegates who work for your organization",
     migrations_panel_list_empty:
       "There are no delegates working for your organization",
-    close: "Close"
+    close: "Close",
+    migrations_panel_start_migration: "Import selected",
+    migration_status_todo: "to be started yet",
+    migration_status_doing: "executing",
+    migration_status_done: "completed",
+    migration_status_failed: "failed"
   },
   templates: {
     edit: "Edit",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -201,6 +201,15 @@ const en = {
     add: "Add a server",
     default: "default"
   },
+  subscription_migrations: {
+    open_migrations_panel: "Import Services",
+    migrations_summary_title:
+      "If you already manage Services in IO Backoffice, you can import them here",
+    migrations_summary_latest: "Import status",
+    migrations_summary_latest_empty: "No import has been started yet",
+    disclaimer:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. In non mauris enim. Aenean pellentesque tristique elit sed pulvinar. Non verranno importati i profili dei delegati associati ai servizi che stai importando, ma solo i servizi stessi. Per tanto, una volta importati i servizi, i/il Referente/i Amministrativo/i associati a App IO dovranno aggiungere i delegati associati al prodotto nell’apposita sezione Referenti."
+  },
   templates: {
     edit: "Edit",
     send: "Send",

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -200,6 +200,15 @@ const it = {
     add: "Aggiungi un server",
     default: "default"
   },
+  subscription_migrations: {
+    open_migrations_panel: "Importa i Servizi",
+    migrations_summary_title:
+      "Se hai già dei servizi attivi su IO che gestivi nel IO Backoffice puoi importarli qui",
+    migrations_summary_latest: "Stato dell'importazione",
+    migrations_summary_latest_empty: "Nessuna importazioni avviata",
+    disclaimer:
+      "L’importazione dei tuoi servizi dal portale IO Backoffice comporta orem ipsum dolor sit amet, consectetur adipiscing elit. In non mauris enim. Aenean pellentesque tristique elit sed pulvinar. Non verranno importati i profili dei delegati associati ai servizi che stai importando, ma solo i servizi stessi. Per tanto, una volta importati i servizi, i/il Referente/i Amministrativo/i associati a App IO dovranno aggiungere i delegati associati al prodotto nell’apposita sezione Referenti."
+  },
   templates: {
     edit: "Modifica",
     send: "Invia ad un destinatario",

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -214,7 +214,12 @@ const it = {
     migrations_panel_list: "Lista dei delegati che operano per il tuo Ente",
     migrations_panel_list_empty:
       "Non ci sono delegati che operano per il tuo Ente",
-    close: "Chiudi"
+    close: "Chiudi",
+    migrations_panel_start_migration: "Importa selezionati",
+    migration_status_todo: "da avviare",
+    migration_status_doing: "in esecuzione",
+    migration_status_done: "completata",
+    migration_status_failed: "fallita"
   },
   templates: {
     edit: "Modifica",

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -207,7 +207,14 @@ const it = {
     migrations_summary_latest: "Stato dell'importazione",
     migrations_summary_latest_empty: "Nessuna importazioni avviata",
     disclaimer:
-      "L’importazione dei tuoi servizi dal portale IO Backoffice comporta orem ipsum dolor sit amet, consectetur adipiscing elit. In non mauris enim. Aenean pellentesque tristique elit sed pulvinar. Non verranno importati i profili dei delegati associati ai servizi che stai importando, ma solo i servizi stessi. Per tanto, una volta importati i servizi, i/il Referente/i Amministrativo/i associati a App IO dovranno aggiungere i delegati associati al prodotto nell’apposita sezione Referenti."
+      "L’importazione dei tuoi servizi dal portale IO Backoffice comporta orem ipsum dolor sit amet, consectetur adipiscing elit. In non mauris enim. Aenean pellentesque tristique elit sed pulvinar. Non verranno importati i profili dei delegati associati ai servizi che stai importando, ma solo i servizi stessi. Per tanto, una volta importati i servizi, i/il Referente/i Amministrativo/i associati a App IO dovranno aggiungere i delegati associati al prodotto nell’apposita sezione Referenti.",
+    migrations_panel_title: "Importa i Servizi",
+    migrations_panel_abstract:
+      "Qui trovi i delegati che operano sui servizi associati al tuo Ente. Per effettuare l’importazione seleziona i delegati che vuoi importare / servizi aggiunti per ogni delegato",
+    migrations_panel_list: "Lista dei delegati che operano per il tuo Ente",
+    migrations_panel_list_empty:
+      "Non ci sono delegati che operano per il tuo Ente",
+    close: "Chiudi"
   },
   templates: {
     edit: "Modifica",

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -103,7 +103,6 @@ class Dashboard extends Component<Props, DashboardState> {
               </section>
               {showModal && (
                 <MigrationsPanel
-                  show={showModal}
                   onClose={() => this.setState({ showModal: false })}
                 />
               )}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -12,12 +12,19 @@ import { RouteComponentProps } from "react-router";
 
 import "./Dashboard.css";
 
+import SummaryBox from "../components/subscription-migrations/SummaryBox";
 import {
   MessageDocument,
   MessagePostAndPersistResult
 } from "../utils/operations";
 import { ContactDocument } from "../workers/getProfile";
 import { TemplateDocument } from "./Message";
+
+import { get } from "lodash";
+import { PublicConfig } from "../../generated/definitions/backend/PublicConfig";
+import { getFromBackend } from "../utils/backend";
+import ff from "../utils/feature-flags";
+import { SelfCareSessionConfig } from "../utils/session/selfcare";
 
 type Props = RouteComponentProps<
   {},
@@ -26,7 +33,18 @@ type Props = RouteComponentProps<
 > &
   WithNamespaces;
 
-class Dashboard extends Component<Props, never> {
+type DashboardState = {
+  applicationConfig: PublicConfig;
+};
+
+class Dashboard extends Component<Props, DashboardState> {
+  public async componentDidMount() {
+    const applicationConfig = await getFromBackend<PublicConfig>({
+      path: "configuration"
+    });
+    this.setState({ applicationConfig });
+  }
+
   private getCard<T = {}>(docs: ReadonlyArray<T>, cardTextKey: string) {
     const { t } = this.props;
     return (
@@ -40,35 +58,45 @@ class Dashboard extends Component<Props, never> {
   }
   public render() {
     const { location } = this.props;
-
+    const applicationConfig = get(this.state, "applicationConfig");
     return (
-      <section className="d-flex">
-        <section className="position-fixed dashboard--notifications-container">
-          {location.state &&
-            Array.isArray(location.state) &&
-            location.state.map(info => {
-              return <Notification key={info._id} info={info} />;
-            })}
+      <>
+        <section className="d-flex">
+          <section className="position-fixed dashboard--notifications-container">
+            {location.state &&
+              Array.isArray(location.state) &&
+              location.state.map(info => {
+                return <Notification key={info._id} info={info} />;
+              })}
+          </section>
+          <Find<TemplateDocument>
+            selector={{
+              type: "template"
+            }}
+            render={({ docs }) => this.getCard(docs, "templates")}
+          />
+          <Find<MessageDocument>
+            selector={{
+              type: "message"
+            }}
+            render={({ docs }) => this.getCard(docs, "messages")}
+          />
+          <Find<ContactDocument>
+            selector={{
+              type: "contact"
+            }}
+            render={({ docs }) => this.getCard(docs, "contacts")}
+          />
         </section>
-        <Find<TemplateDocument>
-          selector={{
-            type: "template"
-          }}
-          render={({ docs }) => this.getCard(docs, "templates")}
-        />
-        <Find<MessageDocument>
-          selector={{
-            type: "message"
-          }}
-          render={({ docs }) => this.getCard(docs, "messages")}
-        />
-        <Find<ContactDocument>
-          selector={{
-            type: "contact"
-          }}
-          render={({ docs }) => this.getCard(docs, "contacts")}
-        />
-      </section>
+        {ff("SUBSCRIPTION_MIGRATIONS_ENABLED") &&
+          SelfCareSessionConfig.is(applicationConfig) && (
+            <section className="d-flex">
+              <div className="m-3 p-3 card">
+                <SummaryBox onSubmitHandler={() => console.log("noop")} />
+              </div>
+            </section>
+          )}
+      </>
     );
   }
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -12,8 +12,8 @@ import { RouteComponentProps } from "react-router";
 
 import "./Dashboard.css";
 
-import SummaryBox from "../components/subscription-migrations/SummaryBox";
 import MigrationsPanel from "../components/subscription-migrations/MigrationsPanel";
+import SummaryBox from "../components/subscription-migrations/SummaryBox";
 import {
   MessageDocument,
   MessagePostAndPersistResult
@@ -96,10 +96,17 @@ class Dashboard extends Component<Props, DashboardState> {
             <>
               <section className="d-flex">
                 <div className="m-3 p-3 card">
-                  <SummaryBox onSubmitHandler={() => this.setState({ showModal: true })} />
+                  <SummaryBox
+                    onSubmitHandler={() => this.setState({ showModal: true })}
+                  />
                 </div>
               </section>
-              {showModal && <MigrationsPanel show={showModal} onClose={() => this.setState({ showModal: false })} />}
+              {showModal && (
+                <MigrationsPanel
+                  show={showModal}
+                  onClose={() => this.setState({ showModal: false })}
+                />
+              )}
             </>
           )}
       </>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -13,6 +13,7 @@ import { RouteComponentProps } from "react-router";
 import "./Dashboard.css";
 
 import SummaryBox from "../components/subscription-migrations/SummaryBox";
+import MigrationsPanel from "../components/subscription-migrations/MigrationsPanel";
 import {
   MessageDocument,
   MessagePostAndPersistResult
@@ -35,6 +36,7 @@ type Props = RouteComponentProps<
 
 type DashboardState = {
   applicationConfig: PublicConfig;
+  showModal: boolean;
 };
 
 class Dashboard extends Component<Props, DashboardState> {
@@ -59,6 +61,7 @@ class Dashboard extends Component<Props, DashboardState> {
   public render() {
     const { location } = this.props;
     const applicationConfig = get(this.state, "applicationConfig");
+    const showModal = get(this.state, "showModal");
     return (
       <>
         <section className="d-flex">
@@ -90,11 +93,14 @@ class Dashboard extends Component<Props, DashboardState> {
         </section>
         {ff("SUBSCRIPTION_MIGRATIONS_ENABLED") &&
           SelfCareSessionConfig.is(applicationConfig) && (
-            <section className="d-flex">
-              <div className="m-3 p-3 card">
-                <SummaryBox onSubmitHandler={() => console.log("noop")} />
-              </div>
-            </section>
+            <>
+              <section className="d-flex">
+                <div className="m-3 p-3 card">
+                  <SummaryBox onSubmitHandler={() => this.setState({ showModal: true })} />
+                </div>
+              </section>
+              {showModal && <MigrationsPanel show={showModal} onClose={() => this.setState({ showModal: false })} />}
+            </>
           )}
       </>
     );

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -1,0 +1,4 @@
+type AllowedFeatureFlag = "SUBSCRIPTION_MIGRATIONS_ENABLED";
+
+export default (flag: AllowedFeatureFlag): boolean =>
+  window.localStorage.getItem(`FF_${flag}`) === "true";


### PR DESCRIPTION
Following #202, it shows the list of Delegates for which run migrations along with the status of the migration. Each Delegate can be selected to start migrating their services. So far, the migration procedure isn't implemented yet and an alart is produced instead.

Migration status is computed by [this algorithm](https://github.com/pagopa/io-developer-portal-frontend/blob/53cb97e8ab486df6609d81fd2c3702a76f0f228a/src/components/subscription-migrations/MigrationsPanel.tsx#L43).

**Screenshots**
![Screen Shot 2022-03-07 at 13 00 07](https://user-images.githubusercontent.com/265564/157030532-2d053633-a0fa-4f39-a9ce-c3c42e34420e.png)

