### PR TITLE
[IC-499] Add Require Secure Channels field

### DIFF
--- a/src/components/input/AdminFields.tsx
+++ b/src/components/input/AdminFields.tsx
@@ -105,6 +105,17 @@ const AdminFields = ({
 
         <div className="mt-5">
           <input
+            name="require_secure_channels"
+            type="checkbox"
+            defaultChecked={service.require_secure_channels}
+            onChange={onChange}
+            className="mb-4 mr-2"
+          />
+          <label className="m-0">{t("require_secure_channels")}</label>
+        </div>
+
+        <div className="mt-5">
+          <input
             name="is_visible"
             type="checkbox"
             defaultChecked={service.is_visible}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -133,6 +133,7 @@ const en = {
     example_authorized_ips: "(i.e. 192.168.200.25/32;192.168.200.26/32)",
     max_allowed_payment_amount: "Maximum allowd payment amount",
     visible_service: "Visible in service list",
+    require_secure_channels: "Require Secure Channels",
     eurocents: "eurocents",
     edit: "Edit service's details",
     save: "Save service's details",

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -133,6 +133,7 @@ const it = {
     example_authorized_ips: "(esempio 192.168.200.25/32;192.168.200.26/32)",
     max_allowed_payment_amount: "Importo massimo autorizzato",
     visible_service: "Visibile nella lista servizi",
+    require_secure_channels: "Richiede canali sicuri",
     eurocents: "eurocents",
     edit: "Modifica i dati del servizio",
     save: "Salva i dati del servizio",

--- a/src/pages/SubscriptionService.tsx
+++ b/src/pages/SubscriptionService.tsx
@@ -243,6 +243,7 @@ class SubscriptionService extends Component<Props, SubscriptionServiceState> {
         service
       })
     );
+    console.log(this.state);
   };
 
   public handleMetadataChange = (
@@ -491,6 +492,7 @@ class SubscriptionService extends Component<Props, SubscriptionServiceState> {
           authorized_cidrs: service.authorized_cidrs,
           authorized_recipients: service.authorized_recipients,
           is_visible: service.is_visible,
+          require_secure_channels: service.require_secure_channels,
           service_metadata: service.service_metadata
         })
       }


### PR DESCRIPTION
The field Require Secure Channels is missing on the frontend of Developer Portal, with this PR we add the capability to turn on or off this boolean field.