### PR TITLE
[#IOPAE-76] Update openapi reference link

### DIFF
--- a/openapi.html
+++ b/openapi.html
@@ -17,7 +17,7 @@
   </head>
   <body>
     <redoc
-      spec-url="https://raw.githubusercontent.com/teamdigitale/io-functions-services/master/openapi/index.yaml"
+      spec-url="https://raw.githubusercontent.com/pagopa/io-functions-services/master/openapi/index.yaml"
       nativeScrollbars="true"
       onlyRequiredInSamples="true"
     ></redoc>


### PR DESCRIPTION
This PR will update the OpenAPI reference link from https://raw.githubusercontent.com/teamdigitale/io-functions-services/master/openapi/index.yaml to https://raw.githubusercontent.com/pagopa/io-functions-services/master/openapi/index.yaml