### PR TITLE
[#IOPAE-104] Subscriptions pagination

### DIFF
--- a/src/components/subscriptions/SubscriptionsLoader.css
+++ b/src/components/subscriptions/SubscriptionsLoader.css
@@ -1,8 +1,8 @@
-.profile--services-progess-hidden {
+.subscriptions-loader--progess-hidden {
     display: none;
   }
   
-.profile--services-progess {
+.subscriptions-loader--progess {
     height: '56px';
     font-size: 18px;
     font-weight: 600;

--- a/src/components/subscriptions/SubscriptionsLoader.tsx
+++ b/src/components/subscriptions/SubscriptionsLoader.tsx
@@ -1,0 +1,55 @@
+import React, { Component, Fragment } from "react";
+
+import { WithNamespaces, withNamespaces } from "react-i18next";
+
+import "./SubscriptionsLoader.css";
+
+type OwnProps = {
+  hasMoreSubscriptions: boolean;
+  areSubscriptionsLoading: boolean;
+  onClick: () => void;
+};
+type Props = WithNamespaces & OwnProps;
+
+class SubscriptionsLoader extends Component<Props, never> {
+  public render() {
+    const { hasMoreSubscriptions, areSubscriptionsLoading, t } = this.props;
+
+    return (
+      <Fragment>
+        <div className="row">
+          <div className="col-md-12 text-center">
+            <button
+              onClick={() => this.props.onClick()}
+              hidden={!hasMoreSubscriptions || areSubscriptionsLoading}
+              className="btn btn-secondary btn-lg btn-block"
+            >
+              {t("load_more_services")}
+            </button>
+            <div
+              className={
+                areSubscriptionsLoading
+                  ? "progress subscriptions-loader--progess"
+                  : "subscriptions-loader--progess-hidden"
+              }
+              style={areSubscriptionsLoading ? { height: "56px" } : undefined}
+            >
+              <div
+                className="progress-bar progress-bar-striped progress-bar-animated"
+                role="progressbar"
+                aria-valuenow={100}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                style={{ width: "100%" }}
+              >
+                {t("loading_services")}
+              </div>
+            </div>
+          </div>
+        </div>
+      </Fragment>
+    );
+  }
+}
+
+export default withNamespaces("profile")(SubscriptionsLoader);

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -90,7 +90,9 @@ const en = {
     service_not_valid: "incomplete or incorrect data",
     service_valid: "active",
     service_loading: "Loading service data",
-    create_new_service: "Create new service"
+    create_new_service: "Create new service",
+    load_more_services: "Load more services",
+    loading_services: "Loading services"
   },
   modal: {
     important: "Important!",

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -90,7 +90,9 @@ const it = {
     service_not_valid: "dati incompleti o incorretti",
     service_valid: "attivo",
     service_loading: "Recupero dati servizio",
-    create_new_service: "Crea un nuovo servizio"
+    create_new_service: "Crea un nuovo servizio",
+    load_more_services: "Carica altri servizi",
+    loading_services: "Caricamento servizi in corso"
   },
   modal: {
     important: "Importante!",

--- a/src/pages/Profile.css
+++ b/src/pages/Profile.css
@@ -1,0 +1,9 @@
+.profile--services-progess-hidden {
+    display: none;
+  }
+  
+.profile--services-progess {
+    height: '56px';
+    font-size: 18px;
+    font-weight: 600;
+  }

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -31,7 +31,7 @@ import {
   ValidService
 } from "../utils/service";
 
-import "./Profile.css";
+import SubscriptionsLoader from "../components/subscriptions/SubscriptionsLoader";
 
 const getMail = (email: string) =>
   email && email !== "" ? atob(email) : undefined;
@@ -112,7 +112,7 @@ const SubscriptionService = ({
 };
 
 // max number of subscriptions loaded for each interaction (pagination)
-const subscriptionsLimit: number = 20;
+const SUBSCRIPTIONS_PAGE_SIZE = 20;
 
 type Props = RouteComponentProps<{ email: string }> & WithNamespaces;
 
@@ -293,7 +293,7 @@ class Profile extends Component<Props, ProfileState> {
       path:
         "subscriptions" +
         (email ? "/" + encodeURIComponent(email) : "") +
-        `?offset=${offset}&limit=${subscriptionsLimit}`
+        `?offset=${offset}&limit=${SUBSCRIPTIONS_PAGE_SIZE}`
     });
 
     const userSubscriptionsObj = Object.keys(userSubscriptions).reduce<
@@ -681,48 +681,15 @@ class Profile extends Component<Props, ProfileState> {
           )}
         </div>
 
-        <div className="row">
-          <div className="col-md-12 text-center">
-            <button
-              onClick={() => {
-                this.loadUserSubscriptions(
-                  this.state.subscriptionsOffset + subscriptionsLimit
-                );
-              }}
-              hidden={
-                !this.state.hasMoreSubscriptions ||
-                (this.state.areSubscriptionsLoading &&
-                  this.state.hasMoreSubscriptions)
-              }
-              className="btn btn-secondary btn-lg btn-block"
-            >
-              {t("load_more_services")}
-            </button>
-            <div
-              className={
-                this.state.areSubscriptionsLoading
-                  ? "progress profile--services-progess"
-                  : "profile--services-progess-hidden"
-              }
-              style={
-                this.state.areSubscriptionsLoading
-                  ? { height: "56px" }
-                  : undefined
-              }
-            >
-              <div
-                className="progress-bar progress-bar-striped progress-bar-animated"
-                role="progressbar"
-                aria-valuenow={100}
-                aria-valuemin={0}
-                aria-valuemax={100}
-                style={{ width: "100%" }}
-              >
-                {t("loading_services")}
-              </div>
-            </div>
-          </div>
-        </div>
+        <SubscriptionsLoader
+          areSubscriptionsLoading={this.state.areSubscriptionsLoading}
+          hasMoreSubscriptions={this.state.hasMoreSubscriptions}
+          onClick={() => {
+            this.loadUserSubscriptions(
+              this.state.subscriptionsOffset + SUBSCRIPTIONS_PAGE_SIZE
+            );
+          }}
+        />
 
         <Confirmation
           isOpen={isConfirmationOpen}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -150,7 +150,7 @@ type ProfileState = {
   showModal: boolean;
   subscriptionsOffset: number;
   hasMoreSubscriptions: boolean;
-  areSubscriptionsLoading: boolean,
+  areSubscriptionsLoading: boolean;
 };
 
 class Profile extends Component<Props, ProfileState> {
@@ -286,11 +286,14 @@ class Profile extends Component<Props, ProfileState> {
 
   private async loadUserSubscriptions(offset: number, email?: string) {
     this.setState({ areSubscriptionsLoading: true });
-    
+
     const userSubscriptions: SubscriptionCollection = await getFromBackend<
       SubscriptionCollection
     >({
-      path: "subscriptions" + (email ? "/" + encodeURIComponent(email) : "") + `?offset=${offset}&limit=${subscriptionsLimit}`
+      path:
+        "subscriptions" +
+        (email ? "/" + encodeURIComponent(email) : "") +
+        `?offset=${offset}&limit=${subscriptionsLimit}`
     });
 
     const userSubscriptionsObj = Object.keys(userSubscriptions).reduce<
@@ -310,9 +313,14 @@ class Profile extends Component<Props, ProfileState> {
     }, {});
 
     this.setState({
-      userSubscriptions: {...this.state.userSubscriptions, ...userSubscriptionsObj},
+      userSubscriptions: {
+        ...this.state.userSubscriptions,
+        ...userSubscriptionsObj
+      },
       subscriptionsOffset: offset,
-      hasMoreSubscriptions: userSubscriptions['nextLink' as keyof typeof userSubscriptions] !== undefined,
+      hasMoreSubscriptions:
+        userSubscriptions["nextLink" as keyof typeof userSubscriptions] !==
+        undefined,
       areSubscriptionsLoading: false
     });
 
@@ -677,16 +685,39 @@ class Profile extends Component<Props, ProfileState> {
           <div className="col-md-12 text-center">
             <button
               onClick={() => {
-                this.loadUserSubscriptions(this.state.subscriptionsOffset + subscriptionsLimit);
+                this.loadUserSubscriptions(
+                  this.state.subscriptionsOffset + subscriptionsLimit
+                );
               }}
-              hidden={!this.state.hasMoreSubscriptions || (this.state.areSubscriptionsLoading && this.state.hasMoreSubscriptions)}
+              hidden={
+                !this.state.hasMoreSubscriptions ||
+                (this.state.areSubscriptionsLoading &&
+                  this.state.hasMoreSubscriptions)
+              }
               className="btn btn-secondary btn-lg btn-block"
             >
               {t("load_more_services")}
             </button>
-            <div className={this.state.areSubscriptionsLoading ? 'progress profile--services-progess' : 'profile--services-progess-hidden'} 
-              style={this.state.areSubscriptionsLoading ?  {height: '56px'} : undefined}>
-              <div className="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow={100} aria-valuemin={0} aria-valuemax={100} style={{width: '100%'}}>
+            <div
+              className={
+                this.state.areSubscriptionsLoading
+                  ? "progress profile--services-progess"
+                  : "profile--services-progess-hidden"
+              }
+              style={
+                this.state.areSubscriptionsLoading
+                  ? { height: "56px" }
+                  : undefined
+              }
+            >
+              <div
+                className="progress-bar progress-bar-striped progress-bar-animated"
+                role="progressbar"
+                aria-valuenow={100}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                style={{ width: "100%" }}
+              >
                 {t("loading_services")}
               </div>
             </div>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -281,7 +281,7 @@ class Profile extends Component<Props, ProfileState> {
     }
 
     // load user's subscriptions (paginated)
-    this.loadUserSubscriptions(this.state.subscriptionsOffset, email);
+    await this.loadUserSubscriptions(this.state.subscriptionsOffset, email);
   }
 
   private async loadUserSubscriptions(offset: number, email?: string) {
@@ -685,7 +685,7 @@ class Profile extends Component<Props, ProfileState> {
           areSubscriptionsLoading={this.state.areSubscriptionsLoading}
           hasMoreSubscriptions={this.state.hasMoreSubscriptions}
           onClick={() => {
-            this.loadUserSubscriptions(
+            void this.loadUserSubscriptions(
               this.state.subscriptionsOffset + SUBSCRIPTIONS_PAGE_SIZE
             );
           }}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -31,6 +31,8 @@ import {
   ValidService
 } from "../utils/service";
 
+import "./Profile.css";
+
 const getMail = (email: string) =>
   email && email !== "" ? atob(email) : undefined;
 
@@ -109,6 +111,9 @@ const SubscriptionService = ({
   ) : null;
 };
 
+// max number of subscriptions loaded for each interaction (pagination)
+const subscriptionsLimit: number = 20;
+
 type Props = RouteComponentProps<{ email: string }> & WithNamespaces;
 
 function isString<T>(value: T | string): value is string {
@@ -143,6 +148,9 @@ type ProfileState = {
   onConfirmOperation: () => void;
   serviceState: { [serviceId: string]: string };
   showModal: boolean;
+  subscriptionsOffset: number;
+  hasMoreSubscriptions: boolean;
+  areSubscriptionsLoading: boolean,
 };
 
 class Profile extends Component<Props, ProfileState> {
@@ -162,7 +170,10 @@ class Profile extends Component<Props, ProfileState> {
     keyDisplay: {},
     isConfirmationOpen: false,
     onConfirmOperation: () => undefined,
-    showModal: false
+    showModal: false,
+    subscriptionsOffset: 0,
+    hasMoreSubscriptions: true,
+    areSubscriptionsLoading: true
   };
 
   public onAddSubscription = async () => {
@@ -269,11 +280,17 @@ class Profile extends Component<Props, ProfileState> {
       this.setState(this.getSubscriptionDefaults(applicationConfig));
     }
 
-    // load all user's subscriptions
+    // load user's subscriptions (paginated)
+    this.loadUserSubscriptions(this.state.subscriptionsOffset, email);
+  }
+
+  private async loadUserSubscriptions(offset: number, email?: string) {
+    this.setState({ areSubscriptionsLoading: true });
+    
     const userSubscriptions: SubscriptionCollection = await getFromBackend<
       SubscriptionCollection
     >({
-      path: "subscriptions" + (email ? "/" + encodeURIComponent(email) : "")
+      path: "subscriptions" + (email ? "/" + encodeURIComponent(email) : "") + `?offset=${offset}&limit=${subscriptionsLimit}`
     });
 
     const userSubscriptionsObj = Object.keys(userSubscriptions).reduce<
@@ -293,7 +310,10 @@ class Profile extends Component<Props, ProfileState> {
     }, {});
 
     this.setState({
-      userSubscriptions: userSubscriptionsObj
+      userSubscriptions: {...this.state.userSubscriptions, ...userSubscriptionsObj},
+      subscriptionsOffset: offset,
+      hasMoreSubscriptions: userSubscriptions['nextLink' as keyof typeof userSubscriptions] !== undefined,
+      areSubscriptionsLoading: false
     });
 
     // load all services related to the user's subscriptions
@@ -651,6 +671,26 @@ class Profile extends Component<Props, ProfileState> {
             },
             []
           )}
+        </div>
+
+        <div className="row">
+          <div className="col-md-12 text-center">
+            <button
+              onClick={() => {
+                this.loadUserSubscriptions(this.state.subscriptionsOffset + subscriptionsLimit);
+              }}
+              hidden={!this.state.hasMoreSubscriptions || (this.state.areSubscriptionsLoading && this.state.hasMoreSubscriptions)}
+              className="btn btn-secondary btn-lg btn-block"
+            >
+              {t("load_more_services")}
+            </button>
+            <div className={this.state.areSubscriptionsLoading ? 'progress profile--services-progess' : 'profile--services-progess-hidden'} 
+              style={this.state.areSubscriptionsLoading ?  {height: '56px'} : undefined}>
+              <div className="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow={100} aria-valuemin={0} aria-valuemax={100} style={{width: '100%'}}>
+                {t("loading_services")}
+              </div>
+            </div>
+          </div>
         </div>
 
         <Confirmation


### PR DESCRIPTION
**Added pagination capability to user's subscription list**
Now the first 20 services will be loaded, and if the user has more services, there will be the possibility to load the remainins by clicking on the appropriate button at the bottom of the list.

#### List of Changes
<!--- Describe your changes in detail -->
- Update *Profile* page with subscriptions pagination capability
- Add *stylesheet file* to *Profile* page
- Add *progress bar* when subscriptions are loading

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Before the changes, all services were loaded all at once and this could create loading problems for users with many services (cases with thousands of services).

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
**Integration Tests with developer-portal-backend**
* (Tested with 16 user’s subscriptions available account)*
* limit=20
  * offset=0 limit=20 —> OK Load One Shot, button “Carica altri servizi” is hidden
*   limit=8
    *  offset=0 limit=8 —> OK Load first page, button “Carica altri servizi” is visible
    *  offset=8 limit=8 —> OK Caricamento seconda pagina, tasto “Carica altri servizi” hidden
*   limit=5
    *  offset=0 —> OK Load first page, button “Carica altri servizi” is visible
    *  offset=5 —> OK Load second page, button “Carica altri servizi” is visible
    *  offset=10 —> OK Load third page, button “Carica altri servizi” is visible
    *  offset=15 —> OK Load forth page, button “Carica altri servizi” is hidden

#### Screenshots (if appropriate):

https://user-images.githubusercontent.com/118166285/209977601-f015bccc-0a0f-4e92-af7f-b643c371a029.mov

*the loaded services are in a test environment, so don't mind the failure details of each single service*

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
