### PR TITLE
[#IOPAE-586] Add require_secure_channels checkbox to service update

### DIFF
--- a/src/components/subscriptions/ApiKey.css
+++ b/src/components/subscriptions/ApiKey.css
@@ -4,12 +4,3 @@
   margin-top: 0px;
   font-size: 16px;
 }
-
-.api-key--info {
-  margin-left: 4px;
-  vertical-align: text-bottom;
-}
-
-.pointer {
-  cursor: pointer;
-}

--- a/src/components/subscriptions/ApiKey.tsx
+++ b/src/components/subscriptions/ApiKey.tsx
@@ -183,7 +183,7 @@ class ApiKey extends Component<Props, ApiKeyState> {
               style={{ fontSize: "18px", fontWeight: 700 }}
             >
               {headerInfo.header}
-              <span className="api-key--info pointer">
+              <span className="info-icon--info pointer">
                 <MdInfoOutline
                   id="info"
                   size="1.3em"

--- a/src/components/subscriptions/InfoIconWithTooltip.css
+++ b/src/components/subscriptions/InfoIconWithTooltip.css
@@ -1,0 +1,8 @@
+.info-icon--info {
+    margin-left: 4px;
+    vertical-align: text-bottom;
+  }
+  
+  .pointer {
+    cursor: pointer;
+  }

--- a/src/components/subscriptions/InfoIconWithTooltip.tsx
+++ b/src/components/subscriptions/InfoIconWithTooltip.tsx
@@ -1,0 +1,54 @@
+import React, { Component } from "react";
+import { WithNamespaces, withNamespaces } from "react-i18next";
+import MdInfoOutline from "react-icons/lib/md/info-outline";
+import { Popover, PopoverBody } from "reactstrap";
+
+import "./InfoIconWithTooltip.css";
+
+type OwnProps = {
+  content: string;
+};
+type Props = WithNamespaces & OwnProps;
+
+type InfoIconWithTooltipState = {
+  isTooltipOpen: boolean;
+};
+
+/**
+ * Component used for displaying an active info icon that trigger a tooltip content.
+ */
+class InfoIconWithTooltip extends Component<Props, InfoIconWithTooltipState> {
+  public state: InfoIconWithTooltipState = {
+    isTooltipOpen: false
+  };
+
+  public render() {
+    const { content } = this.props;
+    const { isTooltipOpen } = this.state;
+
+    const toggleHeaderInfo = () => {
+      this.setState({ isTooltipOpen: !isTooltipOpen });
+    };
+
+    return (
+      <span className="info-icon--info pointer">
+        <MdInfoOutline id="info" size="1.3em" onClick={toggleHeaderInfo} />
+        <Popover
+          style={{
+            fontSize: "14px",
+            fontWeight: 600,
+            textAlign: "center"
+          }}
+          placement="top"
+          target="info"
+          isOpen={isTooltipOpen}
+          toggle={toggleHeaderInfo}
+        >
+          <PopoverBody>{content}</PopoverBody>
+        </Popover>
+      </span>
+    );
+  }
+}
+
+export default withNamespaces("profile")(InfoIconWithTooltip);

--- a/src/components/subscriptions/TitleWithTooltip.tsx
+++ b/src/components/subscriptions/TitleWithTooltip.tsx
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
 import { WithNamespaces, withNamespaces } from "react-i18next";
-import MdInfoOutline from "react-icons/lib/md/info-outline";
-import { Popover, PopoverBody } from "reactstrap";
+import InfoIconWithTooltip from "./InfoIconWithTooltip";
 
 type OwnProps = {
   title: string;
@@ -9,46 +8,18 @@ type OwnProps = {
 };
 type Props = WithNamespaces & OwnProps;
 
-type TitleWithTooltipState = {
-  isHeaderTooltipOpen: boolean;
-};
-
 /**
  * Component used for displaying a title text with an active icon that trigger a tooltip content.
  */
-class TitleWithTooltip extends Component<Props, TitleWithTooltipState> {
-  public state: TitleWithTooltipState = {
-    isHeaderTooltipOpen: false
-  };
-
+class TitleWithTooltip extends Component<Props> {
   public render() {
     const { title, tooltipContent } = this.props;
-    const { isHeaderTooltipOpen } = this.state;
-
-    const toggleHeaderInfo = () => {
-      this.setState({ isHeaderTooltipOpen: !isHeaderTooltipOpen });
-    };
 
     return (
       <div className="row">
         <div className="col pb-2" style={{ fontSize: "18px", fontWeight: 700 }}>
           {title}
-          <span className="api-key--info pointer">
-            <MdInfoOutline id="info" size="1.3em" onClick={toggleHeaderInfo} />
-            <Popover
-              style={{
-                fontSize: "14px",
-                fontWeight: 600,
-                textAlign: "center"
-              }}
-              placement="top"
-              target="info"
-              isOpen={isHeaderTooltipOpen}
-              toggle={toggleHeaderInfo}
-            >
-              <PopoverBody>{tooltipContent}</PopoverBody>
-            </Popover>
-          </span>
+          <InfoIconWithTooltip content={tooltipContent} />
         </div>
       </div>
     );

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -207,7 +207,10 @@ const en = {
     admin_properties: "Admin Properties",
     useful_links: "Useful Links",
     national_service_warn:
-      "ATTENTION: the current service has the scope value equals to NATIONAL"
+      "ATTENTION: the current service has the scope value equals to NATIONAL",
+    sensitive_service: "Sensitive service",
+    sensitive_service_info:
+      "The service is sensitive when it can convey sensitive citizen data. For more details, visit the IO technical guide related section."
   },
   servers: {
     select: "Select your server (endpoint) of choice",

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -206,7 +206,10 @@ const it = {
     admin_properties: "Proprietà Admin",
     useful_links: "Links Utili",
     national_service_warn:
-      "ATTENZIONE: il servizio corrente ha il valore di scope impostato a NATIONAL"
+      "ATTENZIONE: il servizio corrente ha il valore di scope impostato a NATIONAL",
+    sensitive_service: "Servizio sensibile",
+    sensitive_service_info:
+      "Il servizio è sensibile quando può veicolare dati sensibili del cittadino. Per maggiori dettagli, visita la sezione dedicata della guida tecnica di IO."
   },
   servers: {
     select: "Seleziona il server (endpoint) predefinito",

--- a/src/pages/SubscriptionService.tsx
+++ b/src/pages/SubscriptionService.tsx
@@ -44,6 +44,7 @@ import {
   ValidService
 } from "../utils/service";
 import { checkValue, InputValue } from "../utils/validators";
+import InfoIconWithTooltip from "../components/subscriptions/InfoIconWithTooltip";
 
 const { MARKDOWN } = LIMITS;
 const LogoParamsApi = ts.interface({
@@ -503,7 +504,8 @@ class SubscriptionService extends Component<Props, SubscriptionServiceState> {
           authorized_cidrs: service.authorized_cidrs,
           authorized_recipients: service.authorized_recipients,
           is_visible: service.is_visible,
-          service_metadata: service.service_metadata
+          service_metadata: service.service_metadata,
+          require_secure_channels: service.require_secure_channels
         })
       }
     });
@@ -888,6 +890,19 @@ class SubscriptionService extends Component<Props, SubscriptionServiceState> {
                   {errors[`description`] && (
                     <Alert color="danger">{errors[`description`]}</Alert>
                   )}
+                  <div className="mt-1">
+                    <input
+                      name="require_secure_channels"
+                      type="checkbox"
+                      defaultChecked={service.require_secure_channels}
+                      onChange={this.handleInputChange}
+                      className="mb-4 mr-2"
+                    />
+                    <label className="m-0">{t("sensitive_service")}</label>
+                    <InfoIconWithTooltip
+                      content={t("sensitive_service_info")}
+                    />
+                  </div>
                 </div>
               </form>
 

--- a/src/pages/SubscriptionService.tsx
+++ b/src/pages/SubscriptionService.tsx
@@ -30,6 +30,7 @@ import Toastr, {
   ToastrItem,
   ToastrType
 } from "../components/notifications/Toastr";
+import InfoIconWithTooltip from "../components/subscriptions/InfoIconWithTooltip";
 import UploadLogo from "../components/UploadLogo";
 import { StorageContext } from "../context/storage";
 import { getFromBackend, postToBackend, putToBackend } from "../utils/backend";
@@ -44,7 +45,6 @@ import {
   ValidService
 } from "../utils/service";
 import { checkValue, InputValue } from "../utils/validators";
-import InfoIconWithTooltip from "../components/subscriptions/InfoIconWithTooltip";
 
 const { MARKDOWN } = LIMITS;
 const LogoParamsApi = ts.interface({


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Added the possibility to manage `require_secure_channels` checkbox _(labeled as Sensitive Service)_ in service edit/detail section.
This new feature has been developed in the context of _"privacy critical"_ services and the need to control the `require_secure_channels` flag via the Developer Portal.

#### List of Changes
<!--- Describe your changes in detail -->
- refactor of InfoIconWithTootlip generic component (now used both in Manage Key Info and Sensitive Service Info)
- added `require_secure_channels` checkbox in service detail/update section

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested in local with backend and `prod` environment.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

https://github.com/pagopa/io-developer-portal-frontend/assets/118166285/7288ccb1-a00a-449e-8afe-b8f3fb55c786


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

depends on https://github.com/pagopa/io-developer-portal-backend/pull/212