### PR TITLE
[IOPAE-908] Sync check error display

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -197,6 +197,9 @@ const en = {
       "Some fields are missing or incorrect, the service cannot be published",
     publish_error_detail:
       "We ask to correct any errors then submit a new request review again",
+    sync_check_error_title: "Warning!",
+    sync_check_error_message:
+      'You cannot make changes to this service via the Developer Portal because a change is already in progress or the service has been canceled. To make a further change you can use the <a style="color: #0073E6;" href="https://docs.pagopa.it/io-guida-tecnica/api/api-servizi" target="_blank">API Manage</a> for this service.',
     publish_review_title: "We're working on it!",
     publish_review_message:
       "Your service is under review, we will update you as soon as possible",

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -196,6 +196,9 @@ const it = {
       "Alcuni campi risultano mancanti o incorretti, il servizio non può essere pubblicato",
     publish_error_detail:
       "Ti invitiamo a correggere gli errori segnalati e reinviare una nuova richiesta di review",
+    sync_check_error_title: "Attenzione!",
+    sync_check_error_message:
+      'Non è possibile apportare modifiche a questo servizio tramite Developer Portal perché è già in corso una modifica o il servizio è stato cancellato. Per apportare un\'ulteriore modifica puoi usare le <a style="color: #0073E6;" href="https://docs.pagopa.it/io-guida-tecnica/api/api-servizi" target="_blank">API Manage</a> per questo servizio.',
     publish_review_title: "Ci Stiamo lavorando!",
     publish_review_message:
       "Il tuo servizio è in corso di revisione, ti aggiorneremo al più presto",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
We introduce a https://github.com/pagopa/io-developer-portal-backend/pull/215 check on [io-developer-portal-backend](https://github.com/pagopa/io-developer-portal-backend)  to block update service request if there are changes "in progress" by Services CMS "parallel" system.

Therefore, in the case of a service update that returns a `409` with detail=`sync_check_error`, a specific error is shown informing the user of what happened.

_Watch video below to better appreciate development._

#### List of Changes
<!--- Describe your changes in detail -->
- add logic to display error on `src/pages/SubscriptionService.tsx`
- add error message translations

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with mocked backend responses.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

https://github.com/pagopa/io-developer-portal-frontend/assets/118166285/ad685b70-3f96-4232-842a-829c032b2e4d


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
